### PR TITLE
fix: reconnect

### DIFF
--- a/src/main/java/org/tarantool/MsgPackLite.java
+++ b/src/main/java/org/tarantool/MsgPackLite.java
@@ -211,7 +211,7 @@ public class MsgPackLite {
         DataInputStream in = is instanceof DataInputStream ? (DataInputStream) is : new DataInputStream(is);
         int value = in.read();
         if (value < 0) {
-            throw new IllegalArgumentException("No more input available when expecting a value");
+            throw new CommunicationException("No more input available when expecting a value");
         }
         switch ((byte) value) {
         case MP_NULL:


### PR DESCRIPTION
При создании сокета из конструктора  - TarantoolClientImpl(String host, int port, long batchTimeout)  за жизненым циклом следим мы - в случае ошибок пытаемся переконектиться.
Тест был произведен обычным отключением сервера тарантула - самое интересное что после отключение экземпляр сокета в любом случае выдает channel.isConnected() = true, поэтому где code == -1 сами делаем chnanel.close и пересоеденяемся
