### PR TITLE
Safe close CountInputStream on Exception

### DIFF
--- a/src/main/java/org/tarantool/TarantoolBase.java
+++ b/src/main/java/org/tarantool/TarantoolBase.java
@@ -64,6 +64,11 @@ public abstract class TarantoolBase<Result> extends AbstractTarantoolOps<Integer
             } catch (IOException ignored) {
 
             }
+            try {
+                cis.close();
+            } catch (IOException ignored) {
+
+            }
             throw new CommunicationException("Couldn't connect to tarantool", e);
         }
     }

--- a/src/main/java/org/tarantool/TarantoolClientImpl.java
+++ b/src/main/java/org/tarantool/TarantoolClientImpl.java
@@ -141,6 +141,11 @@ public class TarantoolClientImpl extends TarantoolBase<Future<List<?>>> implemen
             } catch (IOException ignored) {
 
             }
+            try {
+                cis.close();
+            } catch (IOException ignored) {
+
+            }
             throw new CommunicationException("Couldn't connect to tarantool", e);
         }
         channel.configureBlocking(false);


### PR DESCRIPTION
Fix for java.io.IOException:

org.tarantool.CommunicationException: Couldn't connect to tarantool
        at org.tarantool.TarantoolClientImpl.connect(TarantoolClientImpl.java:144)
        at org.tarantool.TarantoolClientImpl.reconnect(TarantoolClientImpl.java:108)
        at org.tarantool.TarantoolClientImpl$1.run(TarantoolClientImpl.java:65)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Too many open files
        at sun.nio.ch.IOUtil.makePipe(Native Method)
        at sun.nio.ch.EPollSelectorImpl.<init>(EPollSelectorImpl.java:65)
        at sun.nio.ch.EPollSelectorProvider.openSelector(EPollSelectorProvider.java:36)
        at org.tarantool.ByteBufferInputStream.<init>(ByteBufferInputStream.java:18)
        at org.tarantool.TarantoolClientImpl.connect(TarantoolClientImpl.java:119)