### PR TITLE
remove Callable execution during msgpack serialization

### DIFF
--- a/src/main/java/org/tarantool/MsgPackLite.java
+++ b/src/main/java/org/tarantool/MsgPackLite.java
@@ -72,13 +72,6 @@ public class MsgPackLite {
 
     public void pack(Object item, OutputStream os) throws IOException {
         DataOutputStream out = new DataOutputStream(os);
-        if (item instanceof Callable) {
-            try {
-                item = ((Callable) item).call();
-            } catch (Exception e) {
-                throw new IllegalArgumentException(e);
-            }
-        }
         if (item == null) {
             out.write(MP_NULL);
         } else if (item instanceof Boolean) {


### PR DESCRIPTION
Callable are intended for executing something in separate thread(s) - simply executing them in the same thread during serialization is really misleading