### PR TITLE
removing not used junit4 and unnecessary parts for junit5 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>jar</packaging>
     <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <junit.jupiter.version>5.3.0</junit.jupiter.version>
+      <junit.jupiter.version>5.3.1</junit.jupiter.version>
     </properties>
     <name>Tarantool Connector for Java</name>
     <url>https://github.com/tarantool/tarantool-java</url>
@@ -55,26 +55,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
- junit4 is not used - lets remove it to not clutter things
- junit-jupiter-api is a transitive dependency of junit-jupiter-engine
- junit-vintage-engine is needed to run junit4 tests with junit5 infra - removing junit4 lets remove it too
- update to junit 5.3.1 - hotfix release a day or two after 5.3.0 (I don't think that 5.3.0 bugs will affect tarantool-java, but it is better to be safe)