### PR TITLE
Use tarantool from 2x bucket in CI

### DIFF
--- a/src/test/travis.pre.sh
+++ b/src/test/travis.pre.sh
@@ -2,19 +2,19 @@
 
 set -e 
 
-# We need tarantool 2.0 for jdbc/sql.
-curl http://download.tarantool.org/tarantool/2.0/gpgkey | sudo apt-key add -
+# We need tarantool 2.* for jdbc/sql.
+curl http://download.tarantool.org/tarantool/2x/gpgkey | sudo apt-key add -
 release=`lsb_release -c -s`
 
 sudo rm -f /etc/apt/sources.list.d/*tarantool*.list
-sudo tee /etc/apt/sources.list.d/tarantool_2.0.list <<- EOF
-deb http://download.tarantool.org/tarantool/2.0/ubuntu/ $release main
-deb-src http://download.tarantool.org/tarantool/2.0/ubuntu/ $release main
+sudo tee /etc/apt/sources.list.d/tarantool_2x.list <<- EOF
+deb http://download.tarantool.org/tarantool/2x/ubuntu/ $release main
+deb-src http://download.tarantool.org/tarantool/2x/ubuntu/ $release main
 EOF
 
 sudo apt-get update
 sudo apt-get -y install tarantool tarantool-common
 
 sudo cp src/test/instance.lua /etc/tarantool/instances.enabled/jdk-testing.lua
-sudo tarantoolctl stop  example
+sudo tarantoolctl stop example
 sudo tarantoolctl start jdk-testing


### PR DESCRIPTION
Alpha and beta releases are now deployed to 2x repository instead of
2.0. So upcoming 2.1 beta release and its updates will be in this
repository. Now last tarantool 2.0.\*.\* is in this repository too.