### PR TITLE
jdbc: fix tests on tarantool 2.1

### DIFF
--- a/src/test/java/org/tarantool/TestUtils.java
+++ b/src/test/java/org/tarantool/TestUtils.java
@@ -71,6 +71,23 @@ public class TestUtils {
         }
     }
 
+    public static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(2 * bytes.length);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    public static byte[] fromHex(String hex) {
+        assert hex.length() % 2 == 0;
+        byte[] data = new byte[hex.length() / 2];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = Integer.decode("0x" + hex.charAt(i*2) + hex.charAt(i*2+1)).byteValue();
+        }
+        return data;
+    }
+
     /**
      * See waitReplication(TarantoolClientImpl client, int timeout).
      */

--- a/src/test/java/org/tarantool/jdbc/AbstractJdbcIT.java
+++ b/src/test/java/org/tarantool/jdbc/AbstractJdbcIT.java
@@ -7,22 +7,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.tarantool.TarantoolConnection;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.tarantool.TestUtils.makeInstanceEnv;
+import static org.tarantool.jdbc.SqlTestUtils.getCreateTableSQL;
 
 import org.tarantool.TarantoolControl;
 
@@ -41,78 +37,14 @@ public abstract class AbstractJdbcIT {
     private static String[] initSql = new String[] {
             "CREATE TABLE test(id INT PRIMARY KEY, val VARCHAR(100))",
             "INSERT INTO test VALUES (1, 'one'), (2, 'two'), (3, 'three')",
-
-            "CREATE TABLE test_types(" +
-                    "f1 INT PRIMARY KEY, " +
-                    "f2 CHAR(4), " +
-                    "f3 VARCHAR(100), " +
-                    "f4 LONGVARCHAR(100), " +
-                    "f5 NUMERIC, " +
-                    "f6 DECIMAL, " +
-                    "f7 BIT, " +
-                    "f8 TINYINT, " +
-                    "f9 SMALLINT, " +
-                    "f10 INTEGER, " +
-                    "f11 BIGINT," +
-                    "f12 REAL, " +
-                    "f13 FLOAT, " +
-                    "f14 BINARY(4), " +
-                    "f15 VARBINARY(128), " +
-                    "f16 LONGVARBINARY(2048), " +
-                    "f17 DATE, " +
-                    "f18 TIME, " +
-                    "f19 TIMESTAMP)",
-
-            "INSERT INTO test_types VALUES(" +
-                    "1," +
-                    "'abcd'," + //CHAR
-                    "'000000000000000000001'," + //VARCHAR
-                    "'0000000000000000000000000000000001'," + //LONGVARCHAR
-                    "100," + // NUMERIC
-                    "100.1," + // DECIMAL
-                    "1," + //BIT
-                    "7," + //TINYINT
-                    "1000," + //SMALLINT
-                    "100," + //INTEGER
-                    "100000000000000000," + //BIGINT
-                    "-100.2," + //REAL
-                    "100.3," + //FLOAT
-                    "X'01020304'," + //BINARY
-                    "X'0102030405'," +//VARBINARY
-                    "X'010203040506'," + //LONGVARBINARY
-                    "'1983-03-14'," + //DATE
-                    "'12:01:06'," + //TIME
-                    "129479994)", //TIMESTAMP
-
-            "CREATE TABLE test_compound(id1 INT, id2 INT, val VARCHAR(100), PRIMARY KEY (id2, id1))"
+            "CREATE TABLE test_compound(id1 INT, id2 INT, val VARCHAR(100), PRIMARY KEY (id2, id1))",
+            getCreateTableSQL("test_types", TntSqlType.values())
     };
 
     private static String[] cleanSql = new String[] {
             "DROP TABLE IF EXISTS test",
             "DROP TABLE IF EXISTS test_types",
             "DROP TABLE IF EXISTS test_compound"
-    };
-
-    static Object[] testRow = new Object[] {
-        1,
-        "abcd",
-        "000000000000000000001",
-        "0000000000000000000000000000000001",
-        BigDecimal.valueOf(100),
-        BigDecimal.valueOf(100.1),
-        Boolean.FALSE,
-        (byte)7,
-        (short)1000,
-        100,
-        100000000000000000L,
-        -100.2f,
-        100.3d,
-        new BigInteger("01020304", 16).toByteArray(),
-        new BigInteger("0102030405", 16).toByteArray(),
-        new BigInteger("010203040506", 16).toByteArray(),
-        Date.valueOf("1983-03-14"),
-        Time.valueOf("12:01:06"),
-        new Timestamp(129479994)
     };
 
     protected static TarantoolControl control;
@@ -151,7 +83,7 @@ public abstract class AbstractJdbcIT {
             conn.close();
     }
 
-    private static void sqlExec(String[] text) {
+    protected static void sqlExec(String... text) {
         TarantoolConnection con = makeConnection();
         try {
             for (String cmd : text)

--- a/src/test/java/org/tarantool/jdbc/JdbcDatabaseMetaDataIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcDatabaseMetaDataIT.java
@@ -46,10 +46,10 @@ public class JdbcDatabaseMetaDataIT extends AbstractJdbcIT {
         assertEquals("TEST", rs.getString("TABLE_NAME"));
 
         assertTrue(rs.next());
-        assertEquals("TEST_TYPES", rs.getString("TABLE_NAME"));
+        assertEquals("TEST_COMPOUND", rs.getString("TABLE_NAME"));
 
         assertTrue(rs.next());
-        assertEquals("TEST_COMPOUND", rs.getString("TABLE_NAME"));
+        assertEquals("TEST_TYPES", rs.getString("TABLE_NAME"));
 
         assertFalse(rs.next());
 

--- a/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
@@ -1,5 +1,6 @@
 package org.tarantool.jdbc;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.function.Executable;
@@ -9,8 +10,6 @@ import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -20,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class JdbcPreparedStatementIT extends AbstractJdbcIT {
+public class JdbcPreparedStatementIT extends JdbcTypesIT {
     private PreparedStatement prep;
 
     @AfterEach
@@ -71,68 +70,6 @@ public class JdbcPreparedStatementIT extends AbstractJdbcIT {
         assertEquals(1, count);
 
         assertEquals("thousand", getRow("test", 1000).get(1));
-    }
-
-    @Test
-    public void testSetParameter() throws SQLException {
-        prep = conn.prepareStatement("INSERT INTO test_types VALUES (" +
-                "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-        assertNotNull(prep);
-
-        prep.setInt(1, 1000);//INT
-        prep.setString(2, (String)testRow[1]);//CHAR
-        prep.setString(3, (String)testRow[2]);//VARCHAR
-        prep.setString(4, (String)testRow[3]);//LONGVARCHAR
-        prep.setBigDecimal(5, (BigDecimal)testRow[4]);//NUMERIC
-        prep.setBigDecimal(6, (BigDecimal)testRow[5]);//DECIMAL
-        prep.setBoolean(7, (Boolean)testRow[6]);//BIT
-        prep.setByte(8, (Byte)testRow[7]);//TINYINT
-        prep.setShort(9, (Short)testRow[8]);//SMALLINT
-        prep.setInt(10, (Integer)testRow[9]);//INTEGER
-        prep.setLong(11, (Long)testRow[10]);//BIGINT
-        prep.setFloat(12, (Float)testRow[11]);//REAL
-        prep.setDouble(13, (Double)testRow[12]);//FLOAT
-        prep.setBytes(14, (byte[])testRow[13]);//BINARY
-        prep.setBytes(15, (byte[])testRow[14]);//VARBINARY
-        prep.setBytes(16, (byte[])testRow[15]);//LONGVARBINARY
-        prep.setDate(17, (Date)testRow[16]);//DATE
-        prep.setTime(18, (Time)testRow[17]);//TIME
-        prep.setTimestamp(19, (Timestamp)testRow[18]);//TIMESTAMP
-
-        int count = prep.executeUpdate();
-        assertEquals(1, count);
-
-        prep.close();
-
-        prep = conn.prepareStatement("SELECT * FROM test_types WHERE f1 = ?");
-        prep.setInt(1, 1000);
-
-        ResultSet rs = prep.executeQuery();
-        assertNotNull(rs);
-
-        assertTrue(rs.next());
-        assertEquals(1000, rs.getInt(1));//INT
-        assertEquals(testRow[1], rs.getString(2));//CHAR
-        assertEquals(testRow[2], rs.getString(3));//VARCHAR
-        assertEquals(testRow[3], rs.getString(4)); //LONGVARCHAR
-        assertEquals(testRow[4], rs.getBigDecimal(5));//NUMERIC
-        assertEquals(testRow[5], rs.getBigDecimal(6));//DECIMAL
-        assertEquals(testRow[6], rs.getBoolean(7));//BIT
-        assertEquals(testRow[7], rs.getByte(8));//TINYINT
-        assertEquals(testRow[8], rs.getShort(9));//SMALLINT
-        assertEquals(testRow[9], rs.getInt(10));//INTEGER
-        assertEquals(testRow[10], rs.getLong(11));//BIGINT
-        assertEquals((Float)testRow[11], rs.getFloat(12), 1e-10f);//REAL
-        assertEquals((Double)testRow[12], rs.getDouble(13), 1e-10d);//FLOAT
-        //Issue#45
-        //assertTrue(Arrays.equals((byte[])testRow[13], rs.getBytes(14)));//BINARY
-        //assertTrue(Arrays.equals((byte[])testRow[14], rs.getBytes(15)));//VARBINARY
-        //assertTrue(Arrays.equals((byte[])testRow[15], rs.getBytes(16)));//LONGVARBINARY
-        assertEquals(testRow[16], rs.getDate(17));//DATE
-        assertEquals(testRow[17], rs.getTime(18));//TIME
-        assertEquals(testRow[18], rs.getTimestamp(19));//TIMESTAMP
-
-        rs.close();
     }
 
     @Test
@@ -223,5 +160,80 @@ public class JdbcPreparedStatementIT extends AbstractJdbcIT {
             assertEquals("Connection is closed.", e.getMessage());
         }
         assertEquals(3, i);
+    }
+
+    @Test
+    public void testSetByte() throws SQLException {
+        makeHelper(Byte.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(BYTE_VALS)
+        .testSetParameter();
+    }
+
+    @Test
+    public void testSetInt() throws SQLException {
+        makeHelper(Integer.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(INT_VALS)
+        .testSetParameter();
+    }
+
+    @Test
+    public void testSetLong() throws SQLException {
+        makeHelper(Long.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(LONG_VALS)
+        .testSetParameter();
+    }
+
+    @Test
+    public void testSetString() throws SQLException {
+        makeHelper(String.class)
+        .setColumns(TntSqlType.CHAR, TntSqlType.VARCHAR, TntSqlType.TEXT)
+        .setValues(STRING_VALS)
+        .testSetParameter();
+    }
+
+    @Test
+    public void testSetFloat() throws SQLException {
+        makeHelper(Float.class)
+        .setColumns(TntSqlType.REAL)
+        .setValues(FLOAT_VALS)
+        .testSetParameter();
+    }
+
+    @Test
+    public void testSetDouble() throws SQLException {
+        makeHelper(Double.class)
+        .setColumns(TntSqlType.FLOAT, TntSqlType.DOUBLE)
+        .setValues(DOUBLE_VALS)
+        .testSetParameter();
+    }
+
+    @Test
+    public void testSetBigDecimal() throws SQLException {
+        makeHelper(BigDecimal.class)
+        .setColumns(TntSqlType.DECIMAL, TntSqlType.DECIMAL_PREC, TntSqlType.DECIMAL_PREC_SCALE,
+            TntSqlType.NUMERIC, TntSqlType.NUMERIC_PREC, TntSqlType.NUMERIC_PREC_SCALE,
+            TntSqlType.NUM, TntSqlType.NUM_PREC, TntSqlType.NUM_PREC_SCALE)
+        .setValues(BIGDEC_VALS)
+        .testSetParameter();
+    }
+
+    @Disabled("Issue#45. Binary string is reported back as char string by tarantool")
+    @Test
+    public void testSetByteArray() throws SQLException {
+        makeHelper(byte[].class)
+        .setColumns(TntSqlType.BLOB)
+        .setValues(BINARY_VALS)
+        .testSetParameter();
+    }
+
+    @Test
+    public void testSetDate() throws SQLException {
+        makeHelper(Date.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(DATE_VALS)
+        .testSetParameter();
     }
 }

--- a/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
@@ -4,17 +4,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class JdbcResultSetIT extends AbstractJdbcIT {
+public class JdbcResultSetIT extends JdbcTypesIT {
     private Statement stmt;
 
     @BeforeEach
@@ -51,64 +51,76 @@ public class JdbcResultSetIT extends AbstractJdbcIT {
     }
 
     @Test
-    public void testGetColumnByIdx() throws SQLException {
-        ResultSet rs = stmt.executeQuery("SELECT * FROM test_types");
-        assertNotNull(rs);
-        assertTrue(rs.next());
-
-        assertEquals(testRow[0], rs.getInt(1));//INT
-        assertEquals(testRow[1], rs.getString(2));//CHAR
-        assertEquals(testRow[2], rs.getString(3));//VARCHAR
-        assertEquals(testRow[3], rs.getString(4)); //LONGVARCHAR
-        assertEquals(testRow[4], rs.getBigDecimal(5));// NUMERIC
-        assertEquals(testRow[5], rs.getBigDecimal(6));// DECIMAL
-        assertEquals(testRow[6], rs.getBoolean(7));//BIT
-        assertEquals(testRow[7], rs.getByte(8));//TINYINT
-        assertEquals(testRow[8], rs.getShort(9));//SMALLINT
-        assertEquals(testRow[9], rs.getInt(10));//INTEGER
-        assertEquals(testRow[10], rs.getLong(11));//BIGINT
-        assertEquals((Float)testRow[11], rs.getFloat(12), 1e-10f);//REAL
-        assertEquals((Double)testRow[12], rs.getDouble(13), 1e-10d);//FLOAT
-        assertTrue(Arrays.equals((byte[])testRow[13], rs.getBytes(14)));//BINARY
-        assertTrue(Arrays.equals((byte[])testRow[14], rs.getBytes(15)));//VARBINARY
-        assertTrue(Arrays.equals((byte[])testRow[15], rs.getBytes(16)));//LONGVARBINARY
-
-        //Issue#44
-        //assertEquals(testRow[16], rs.getDate(17));//DATE
-        //assertEquals(testRow[17], rs.getTime(18));//TIME
-        assertEquals(testRow[18], rs.getTimestamp(19)); //TIMESTAMP
-
-        rs.close();
+    public void testGetByteColumn() throws SQLException {
+        makeHelper(Byte.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(BYTE_VALS)
+        .testGetColumn();
     }
 
     @Test
-    public void testGetColumnByName() throws SQLException {
-        ResultSet rs = stmt.executeQuery("SELECT * FROM test_types");
-        assertNotNull(rs);
-        assertTrue(rs.next());
+    public void testGetShortColumn() throws SQLException {
+        makeHelper(Short.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(SHORT_VALS)
+        .testGetColumn();
+    }
 
-        assertEquals(testRow[0], rs.getInt("F1"));//INT
-        assertEquals(testRow[1], rs.getString("F2"));//CHAR
-        assertEquals(testRow[2], rs.getString("F3"));//VARCHAR
-        assertEquals(testRow[3], rs.getString("F4")); //LONGVARCHAR
-        assertEquals(testRow[4], rs.getBigDecimal("F5"));// NUMERIC
-        assertEquals(testRow[5], rs.getBigDecimal("F6"));// DECIMAL
-        assertEquals(testRow[6], rs.getBoolean("F7"));//BIT
-        assertEquals(testRow[7], rs.getByte("F8"));//TINYINT
-        assertEquals(testRow[8], rs.getShort("F9"));//SMALLINT
-        assertEquals(testRow[9], rs.getInt("F10"));//INTEGER
-        assertEquals(testRow[10], rs.getLong("F11"));//BIGINT
-        assertEquals((Float)testRow[11], rs.getFloat("F12"), 1e-10f);//REAL
-        assertEquals((Double)testRow[12], rs.getDouble("F13"), 1e-10d);//FLOAT
-        assertTrue(Arrays.equals((byte[])testRow[13], rs.getBytes("F14")));//BINARY
-        assertTrue(Arrays.equals((byte[])testRow[14], rs.getBytes("F15")));//VARBINARY
-        assertTrue(Arrays.equals((byte[])testRow[15], rs.getBytes("F16")));//LONGVARBINARY
+    @Test
+    public void testGetIntColumn() throws SQLException {
+        makeHelper(Integer.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(INT_VALS)
+        .testGetColumn();
+    }
 
-        //Issue#44
-        //assertEquals(testRow[16], rs.getDate("F17"));//DATE
-        //assertEquals(testRow[17], rs.getTime("F18"));//TIME
-        assertEquals(testRow[18], rs.getTimestamp("F19")); //TIMESTAMP
+    @Test
+    public void testGetLongColumn() throws SQLException {
+        makeHelper(Long.class)
+        .setColumns(TntSqlType.INT, TntSqlType.INTEGER)
+        .setValues(LONG_VALS)
+        .testGetColumn();
+    }
 
-        rs.close();
+    @Test
+    public void testGetBigDecimalColumn() throws SQLException {
+        makeHelper(BigDecimal.class)
+        .setColumns(TntSqlType.DECIMAL, TntSqlType.DECIMAL_PREC, TntSqlType.DECIMAL_PREC_SCALE,
+            TntSqlType.NUMERIC, TntSqlType.NUMERIC_PREC, TntSqlType.NUMERIC_PREC_SCALE,
+            TntSqlType.NUM, TntSqlType.NUM_PREC, TntSqlType.NUM_PREC_SCALE)
+        .setValues(BIGDEC_VALS)
+        .testGetColumn();
+    }
+
+    @Test
+    public void testGetFloatColumn() throws SQLException {
+        makeHelper(Float.class)
+        .setColumns(TntSqlType.REAL)
+        .setValues(FLOAT_VALS)
+        .testGetColumn();
+    }
+
+    @Test
+    public void testGetDoubleColumn() throws SQLException {
+        makeHelper(Double.class)
+        .setColumns(TntSqlType.FLOAT, TntSqlType.DOUBLE)
+        .setValues(DOUBLE_VALS)
+        .testGetColumn();
+    }
+
+    @Test
+    public void testGetStringColumn() throws SQLException {
+        makeHelper(String.class)
+        .setColumns(TntSqlType.CHAR, TntSqlType.VARCHAR, TntSqlType.TEXT)
+        .setValues(STRING_VALS)
+        .testGetColumn();
+    }
+
+    @Test
+    public void testGetByteArrayColumn() throws SQLException {
+        makeHelper(byte[].class)
+        .setColumns(TntSqlType.BLOB)
+        .setValues(BINARY_VALS)
+        .testGetColumn();
     }
 }

--- a/src/test/java/org/tarantool/jdbc/JdbcResultSetMetaDataIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcResultSetMetaDataIT.java
@@ -9,7 +9,6 @@ import java.sql.Statement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JdbcResultSetMetaDataIT extends AbstractJdbcIT {
     @Test
@@ -18,14 +17,16 @@ public class JdbcResultSetMetaDataIT extends AbstractJdbcIT {
         assertNotNull(stmt);
         ResultSet rs = stmt.executeQuery("SELECT * FROM test_types");
         assertNotNull(rs);
-        assertTrue(rs.next());
 
         ResultSetMetaData rsMeta = rs.getMetaData();
 
-        assertEquals(19, rsMeta.getColumnCount());
+        int colCount = 1 + TntSqlType.values().length;
+        assertEquals(colCount, rsMeta.getColumnCount());
+        assertEquals("KEY", rsMeta.getColumnName(1));
 
-        for (int i = 1; i <= 19; i++)
-            assertEquals("F" + i, rsMeta.getColumnName(i));
+        for (int i = 2; i <= colCount; i++) {
+            assertEquals("F" + (i - 2), rsMeta.getColumnName(i));
+        }
 
         rs.close();
         stmt.close();

--- a/src/test/java/org/tarantool/jdbc/JdbcTypesIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcTypesIT.java
@@ -1,0 +1,194 @@
+package org.tarantool.jdbc;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.tarantool.TestUtils.fromHex;
+import static org.tarantool.jdbc.SqlTestUtils.getInsertSQL;
+import static org.tarantool.jdbc.SqlTestUtils.getParameterizedInsertSQL;
+import static org.tarantool.jdbc.SqlTestUtils.getSelectSQL;
+
+public class JdbcTypesIT extends AbstractJdbcIT {
+    private static AtomicInteger KEY_CNTR = new AtomicInteger(1);
+
+    public static Integer[] INT_VALS = new Integer[] { Integer.MIN_VALUE, 0, Integer.MAX_VALUE, 1, 100, -50 };
+    public static Double[] DOUBLE_VALS = new Double[] { 0.0d, Double.MIN_VALUE, Double.MAX_VALUE, 1.00001d, 100.5d };
+    public static Float[] FLOAT_VALS = new Float[] { 0.0f, Float.MIN_VALUE, Float.MAX_VALUE, 1.00001f, 100.5f };
+    public static String[] STRING_VALS = new String[] { "", "1", "A", "test test" };
+    public static Byte[] BYTE_VALS = new Byte[] { Byte.MIN_VALUE, Byte.MAX_VALUE, (byte)0, (byte)100 };
+    public static Short[] SHORT_VALS = new Short[] { Short.MIN_VALUE, Short.MAX_VALUE, (short)0, (short)1000 };
+    public static Long[] LONG_VALS = new Long[] { Long.MIN_VALUE, Long.MAX_VALUE, 0L, 100000000L};
+    public static BigDecimal[] BIGDEC_VALS = new BigDecimal[] { BigDecimal.valueOf(Double.MIN_VALUE),
+        BigDecimal.valueOf(Double.MAX_VALUE), BigDecimal.ZERO, BigDecimal.ONE };
+    public static byte[][] BINARY_VALS = new byte[][] { fromHex(""), fromHex("00"), fromHex("FFFF"),
+        fromHex("0102030405060708") };
+    public static Date[] DATE_VALS = new Date[] { Date.valueOf("1983-03-14"), new Date(129479994) };
+
+    public <T> TestHelper<T> makeHelper(Class<T> cls) {
+        return new TestHelper<T>(cls);
+    }
+
+    class TestHelper<T> {
+        Class<T> cls;
+        T[] vals;
+        TntSqlType[] colTypes;
+        int start;
+
+        TestHelper(Class<T> cls) {
+            this.cls = cls;
+        }
+
+        TestHelper<T> setValues(T... vals) {
+            this.vals = vals;
+            start = KEY_CNTR.getAndAdd(vals.length);
+            return this;
+        }
+
+        TestHelper<T> setColumns(TntSqlType... colTypes) {
+            this.colTypes = colTypes;
+            return this;
+        }
+
+        void testSetParameter() throws SQLException {
+            checkSetParameter();
+            checkResultSetGet();
+        }
+
+        void testGetColumn() throws SQLException {
+            sqlExec(getInsertSQL("test_types", start, colTypes, vals));
+            checkResultSetGet();
+        }
+
+        private void checkSetParameter() throws SQLException {
+            String sql = getParameterizedInsertSQL("test_types", colTypes);
+            PreparedStatement prep = conn.prepareStatement(sql);
+            try {
+                assertNotNull(prep);
+                int count = start;
+                for (T val : vals) {
+                    prep.setInt(1, count++);
+                    for (int col = 0; col < colTypes.length; col++) {
+                        apply(prep, 2 + col, val);
+                    }
+                    assertEquals(1, prep.executeUpdate());
+                }
+            } catch (Throwable e) {
+                throw new SQLException(e);
+            } finally {
+                prep.close();
+            }
+        }
+
+        private void checkResultSetGet() throws SQLException {
+            Statement stmt = conn.createStatement();
+            try {
+                String sql = getSelectSQL("test_types", start, start + vals.length, colTypes);
+                ResultSet rs = stmt.executeQuery(sql);
+                assertNotNull(rs);
+                try {
+                    for (int row = 0; row < vals.length; row++) {
+                        assertTrue(rs.next());
+                        int valIdx = rs.getInt(1) - start;
+                        T val = vals[valIdx];
+                        for (int col = 0; col < colTypes.length; col++) {
+                            TntSqlType tntSqlType = colTypes[col];
+                            check(rs, 2 + col, "F" + tntSqlType.ordinal(), val);
+                        }
+                    }
+                } finally {
+                    rs.close();
+                }
+            } finally {
+                stmt.close();
+            }
+        }
+
+        protected void apply(PreparedStatement ps, int col, T val) throws SQLException {
+            if (cls == Byte.class) {
+                ps.setByte(col, (Byte)val);
+            } else if (cls == Short.class) {
+                ps.setShort(col, (Short)val);
+            } else if (cls == Integer.class) {
+                ps.setInt(col, (Integer)val);
+            } else if (cls == Long.class) {
+                ps.setLong(col, (Long)val);
+            } else if (cls == String.class) {
+                ps.setString(col, (String)val);
+            } else if (cls == Float.class) {
+                ps.setFloat(col, (Float)val);
+            } else if (cls == Double.class) {
+                ps.setDouble(col, (Double)val);
+            } else if (cls == Boolean.class) {
+                ps.setBoolean(col, (Boolean)val);
+            } else if (cls == BigDecimal.class) {
+                ps.setBigDecimal(col, (BigDecimal) val);
+            } else if (cls == byte[].class) {
+                ps.setBytes(col, (byte[])val);
+            } else if (cls == Date.class) {
+                ps.setDate(col, (Date)val);
+            } else if (cls == Time.class) {
+                ps.setTime(col, (Time)val);
+            } else if (cls == Timestamp.class) {
+                ps.setTimestamp(col, (Timestamp)val);
+            } else {
+                throw new IllegalArgumentException("val is of unexpected type " + cls.getName());
+            }
+        }
+
+        protected void check(ResultSet rs, int col, String name, T val) throws SQLException {
+            if (cls == Byte.class) {
+                assertEquals(val, rs.getByte(col));
+                assertEquals(val, rs.getByte(name));
+            } else if (cls == Short.class) {
+                assertEquals(val, rs.getShort(col));
+                assertEquals(val, rs.getShort(name));
+            } else if (cls == Integer.class) {
+                assertEquals(val, rs.getInt(col));
+                assertEquals(val, rs.getInt(name));
+            } else if (cls == Long.class) {
+                assertEquals(val, rs.getLong(col));
+                assertEquals(val, rs.getLong(name));
+            } else if (cls == String.class) {
+                assertEquals(val, rs.getString(col));
+                assertEquals(val, rs.getString(name));
+            } else if (cls == Float.class) {
+                assertEquals((Float)val, rs.getFloat(col), Math.ulp(1.0f));
+                assertEquals((Float)val, rs.getFloat(name), Math.ulp(1.0f));
+            } else if (cls == Double.class) {
+                assertEquals((Double)val, rs.getDouble(col), Math.ulp(1.0d));
+                assertEquals((Double)val, rs.getDouble(name), Math.ulp(1.0d));
+            } else if (cls == Boolean.class) {
+                assertEquals(val, rs.getBoolean(col));
+                assertEquals(val, rs.getBoolean(name));
+            } else if (cls == BigDecimal.class) {
+                assertEquals(0, ((BigDecimal)val).compareTo(rs.getBigDecimal(col)));
+                assertEquals(0, ((BigDecimal)val).compareTo(rs.getBigDecimal(name)));
+            } else if (cls == byte[].class) {
+                assertArrayEquals((byte[])val, rs.getBytes(col));
+                assertArrayEquals((byte[])val, rs.getBytes(name));
+            } else if (cls == Date.class) {
+                assertEquals(val, rs.getDate(col));
+                assertEquals(val, rs.getDate(name));
+            } else if (cls == Time.class) {
+                assertEquals(val, rs.getTime(col));
+                assertEquals(val, rs.getTime(name));
+            } else if (cls == Timestamp.class) {
+                assertEquals(val, rs.getTimestamp(col));
+                assertEquals(val, rs.getTimestamp(name));
+            } else {
+                throw new IllegalArgumentException("val is of unexpected type " + cls.getName());
+            }
+        }
+    }
+}

--- a/src/test/java/org/tarantool/jdbc/SqlTestUtils.java
+++ b/src/test/java/org/tarantool/jdbc/SqlTestUtils.java
@@ -1,0 +1,97 @@
+package org.tarantool.jdbc;
+
+import java.sql.Date;
+
+import static org.tarantool.TestUtils.toHex;
+
+public class SqlTestUtils {
+    public static String getCreateTableSQL(String tableName, TntSqlType[] tntTypes) {
+        StringBuilder sb = new StringBuilder("CREATE TABLE ");
+        sb.append(tableName);
+        sb.append("(KEY INT PRIMARY KEY");
+        for (TntSqlType tntType : tntTypes) {
+            sb.append(", F");
+            sb.append(tntType.ordinal());
+            sb.append(" ");
+            sb.append(tntType.sqlType);
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    public static String getParameterizedInsertSQL(String tableName, TntSqlType[] tntTypes) {
+        StringBuilder sb = new StringBuilder("INSERT INTO ");
+        sb.append(tableName);
+        sb.append("(KEY");
+        for (TntSqlType tntType : tntTypes) {
+            sb.append(", F");
+            sb.append(tntType.ordinal());
+        }
+        sb.append(") VALUES (");
+        sb.append("?"); // KEY value
+        for (TntSqlType ignored : tntTypes) {
+            sb.append(", ?");
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    public static <T> String getInsertSQL(String tableName, int start, TntSqlType[] colTypes, T[] vals) {
+        StringBuilder sb = new StringBuilder("INSERT INTO ");
+        sb.append(tableName);
+        sb.append("(KEY");
+        for (TntSqlType tntType : colTypes) {
+            sb.append(", F");
+            sb.append(tntType.ordinal());
+        }
+        sb.append(") VALUES ");
+        for (int row = 0; row < vals.length; row++) {
+            if (row > 0) {
+                sb.append(", ");
+            }
+            sb.append("(");
+            sb.append(start + row);
+
+            for (TntSqlType ignored : colTypes) {
+                sb.append(", ");
+                sb.append(quoteSqlValue(vals[row]));
+            }
+            sb.append(")");
+        }
+        return sb.toString();
+    }
+
+    public static String getSelectSQL(String tableName, int start, int end, TntSqlType[] tntTypes) {
+        StringBuilder sb = new StringBuilder("SELECT KEY");
+        for (TntSqlType tntType : tntTypes) {
+            sb.append(", F");
+            sb.append(tntType.ordinal());
+        }
+        sb.append(" FROM ");
+        sb.append(tableName);
+        sb.append(" WHERE KEY >= ");
+        sb.append(start);
+        sb.append(" AND KEY < ");
+        sb.append(end);
+        return sb.toString();
+    }
+
+    public static String quoteSqlValue(Object val) {
+        if (val == null)
+            return "null";
+
+        if (val instanceof Boolean)
+            return (Boolean)val ? "1" : "0";
+
+        if (val instanceof String)
+            return "'" + val.toString() + "'";
+
+        if (val instanceof Date)
+            return "'" + val.toString() + "'";
+
+        if (val instanceof byte[])
+            return "X'" + toHex((byte[]) val) + "'";
+
+        return val.toString();
+    }
+}

--- a/src/test/java/org/tarantool/jdbc/TntSqlType.java
+++ b/src/test/java/org/tarantool/jdbc/TntSqlType.java
@@ -1,0 +1,45 @@
+package org.tarantool.jdbc;
+
+/**
+ * Enumeration of SQL types recognizable by tarantool.
+ */
+public enum TntSqlType {
+    FLOAT("FLOAT"),
+
+    DOUBLE("DOUBLE"),
+
+    REAL("REAL"),
+
+    INT("INT"),
+    INTEGER("INTEGER"),
+
+    DECIMAL("DECIMAL"),
+    DECIMAL_PREC("DECIMAL(20)"),
+    DECIMAL_PREC_SCALE("DECIMAL(20,10)"),
+
+    NUMERIC("NUMERIC"),
+    NUMERIC_PREC("NUMERIC(20)"),
+    NUMERIC_PREC_SCALE("NUMERIC(20,10)"),
+
+    NUM("NUM"),
+    NUM_PREC("NUM(20)"),
+    NUM_PREC_SCALE("NUM(20,10)"),
+
+    CHAR("CHAR(128)"),
+
+    VARCHAR("VARCHAR(128)"),
+
+    TEXT("TEXT"),
+
+    BLOB("BLOB");
+
+    //DATE("DATE"),
+    //TIME("TIME"),
+    //TIMESTAMP("TIMESTAMP"),
+
+    public String sqlType;
+
+    TntSqlType(String sqlType) {
+        this.sqlType = sqlType;
+    }
+}

--- a/src/test/travis.pre.sh
+++ b/src/test/travis.pre.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-# We need tarantool 2.0 for jdbc/sql.
-curl http://download.tarantool.org/tarantool/2.0/gpgkey | sudo apt-key add -
+# We need tarantool 2.* for jdbc/sql.
+curl http://download.tarantool.org/tarantool/2x/gpgkey | sudo apt-key add -
 release=`lsb_release -c -s`
 
 sudo rm -f /etc/apt/sources.list.d/*tarantool*.list
-sudo tee /etc/apt/sources.list.d/tarantool_2.0.list <<- EOF
-deb http://download.tarantool.org/tarantool/2.0/ubuntu/ $release main
-deb-src http://download.tarantool.org/tarantool/2.0/ubuntu/ $release main
+sudo tee /etc/apt/sources.list.d/tarantool_2x.list <<- EOF
+deb http://download.tarantool.org/tarantool/2x/ubuntu/ $release main
+deb-src http://download.tarantool.org/tarantool/2x/ubuntu/ $release main
 EOF
 
 sudo apt-get update


### PR DESCRIPTION
Updated jdbc tests following static SQL types
introduction into tarantool 2.1.

Closes #90