### PR TITLE
jdbc: remove the outdated tarantool sql types

### DIFF
--- a/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
@@ -189,7 +189,7 @@ public class JdbcPreparedStatementIT extends JdbcTypesIT {
     @Test
     public void testSetString() throws SQLException {
         makeHelper(String.class)
-        .setColumns(TntSqlType.CHAR, TntSqlType.VARCHAR, TntSqlType.TEXT)
+        .setColumns(TntSqlType.VARCHAR, TntSqlType.TEXT)
         .setValues(STRING_VALS)
         .testSetParameter();
     }
@@ -213,9 +213,7 @@ public class JdbcPreparedStatementIT extends JdbcTypesIT {
     @Test
     public void testSetBigDecimal() throws SQLException {
         makeHelper(BigDecimal.class)
-        .setColumns(TntSqlType.DECIMAL, TntSqlType.DECIMAL_PREC, TntSqlType.DECIMAL_PREC_SCALE,
-            TntSqlType.NUMERIC, TntSqlType.NUMERIC_PREC, TntSqlType.NUMERIC_PREC_SCALE,
-            TntSqlType.NUM, TntSqlType.NUM_PREC, TntSqlType.NUM_PREC_SCALE)
+        .setColumns(TntSqlType.REAL, TntSqlType.FLOAT, TntSqlType.DOUBLE)
         .setValues(BIGDEC_VALS)
         .testSetParameter();
     }
@@ -224,7 +222,7 @@ public class JdbcPreparedStatementIT extends JdbcTypesIT {
     @Test
     public void testSetByteArray() throws SQLException {
         makeHelper(byte[].class)
-        .setColumns(TntSqlType.BLOB)
+        .setColumns(TntSqlType.SCALAR)
         .setValues(BINARY_VALS)
         .testSetParameter();
     }

--- a/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
@@ -85,9 +85,7 @@ public class JdbcResultSetIT extends JdbcTypesIT {
     @Test
     public void testGetBigDecimalColumn() throws SQLException {
         makeHelper(BigDecimal.class)
-        .setColumns(TntSqlType.DECIMAL, TntSqlType.DECIMAL_PREC, TntSqlType.DECIMAL_PREC_SCALE,
-            TntSqlType.NUMERIC, TntSqlType.NUMERIC_PREC, TntSqlType.NUMERIC_PREC_SCALE,
-            TntSqlType.NUM, TntSqlType.NUM_PREC, TntSqlType.NUM_PREC_SCALE)
+        .setColumns(TntSqlType.REAL, TntSqlType.FLOAT, TntSqlType.DOUBLE)
         .setValues(BIGDEC_VALS)
         .testGetColumn();
     }
@@ -111,7 +109,7 @@ public class JdbcResultSetIT extends JdbcTypesIT {
     @Test
     public void testGetStringColumn() throws SQLException {
         makeHelper(String.class)
-        .setColumns(TntSqlType.CHAR, TntSqlType.VARCHAR, TntSqlType.TEXT)
+        .setColumns(TntSqlType.VARCHAR, TntSqlType.TEXT)
         .setValues(STRING_VALS)
         .testGetColumn();
     }
@@ -119,7 +117,7 @@ public class JdbcResultSetIT extends JdbcTypesIT {
     @Test
     public void testGetByteArrayColumn() throws SQLException {
         makeHelper(byte[].class)
-        .setColumns(TntSqlType.BLOB)
+        .setColumns(TntSqlType.SCALAR)
         .setValues(BINARY_VALS)
         .testGetColumn();
     }

--- a/src/test/java/org/tarantool/jdbc/TntSqlType.java
+++ b/src/test/java/org/tarantool/jdbc/TntSqlType.java
@@ -4,37 +4,19 @@ package org.tarantool.jdbc;
  * Enumeration of SQL types recognizable by tarantool.
  */
 public enum TntSqlType {
+
     FLOAT("FLOAT"),
-
     DOUBLE("DOUBLE"),
-
     REAL("REAL"),
 
     INT("INT"),
     INTEGER("INTEGER"),
 
-    DECIMAL("DECIMAL"),
-    DECIMAL_PREC("DECIMAL(20)"),
-    DECIMAL_PREC_SCALE("DECIMAL(20,10)"),
-
-    NUMERIC("NUMERIC"),
-    NUMERIC_PREC("NUMERIC(20)"),
-    NUMERIC_PREC_SCALE("NUMERIC(20,10)"),
-
-    NUM("NUM"),
-    NUM_PREC("NUM(20)"),
-    NUM_PREC_SCALE("NUM(20,10)"),
-
-    CHAR("CHAR(128)"),
-
     VARCHAR("VARCHAR(128)"),
-
     TEXT("TEXT"),
 
-    BLOB("BLOB");
+    SCALAR("SCALAR");
 
-    //DATE("DATE"),
-    //TIME("TIME"),
     //TIMESTAMP("TIMESTAMP"),
 
     public String sqlType;


### PR DESCRIPTION
NUMERIC/DATE-related types were removed and BLOB type
was replaced by SCALAR in scope of new SQL type changes

fixes: #130 