### PR TITLE
Fix a file descriptor leak with wrong user:pass

### DIFF
--- a/src/main/java/org/tarantool/TarantoolConnection.java
+++ b/src/main/java/org/tarantool/TarantoolConnection.java
@@ -28,7 +28,7 @@ public class TarantoolConnection extends TarantoolBase<List<?>> implements Taran
             ByteBuffer packet = createPacket(code, syncId.incrementAndGet(), null, args);
             out.write(packet.array(), 0, packet.remaining());
             out.flush();
-            readPacket(is);
+            readPacket();
             Long c = (Long) headers.get(Key.CODE.getId());
             if (c == 0) {
                 return (List) body.get(Key.DATA.getId());

--- a/src/test/java/org/tarantool/AbstractTarantoolConnectorIT.java
+++ b/src/test/java/org/tarantool/AbstractTarantoolConnectorIT.java
@@ -135,6 +135,10 @@ public abstract class AbstractTarantoolConnectorIT {
         return new TarantoolClientImpl(socketChannelProvider, makeClientConfig());
     }
 
+    protected TarantoolClient makeClient(SocketChannelProvider provider) {
+        return new TarantoolClientImpl(provider, makeClientConfig());
+    }
+
     protected static TarantoolClientConfig makeClientConfig() {
         return fillClientConfig(new TarantoolClientConfig());
     }


### PR DESCRIPTION
Set SO_LINGER to 0 in tests that produce many outgoing connections,
because so many sockets in the TIME_WAIT state can lead to
'java.net.NoRouteToHostException: Cannot assign requested address
(Address not available)' exceptions on Travis-CI.

Fixes #132.