### PR TITLE
Race condition in TarantoolClientImpl

### DIFF
--- a/src/test/java/org/tarantool/ClientReconnectIT.java
+++ b/src/test/java/org/tarantool/ClientReconnectIT.java
@@ -231,7 +231,8 @@ public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
         SocketChannelProvider provider = new TestSocketChannelProvider(host,
             port, RESTART_TIMEOUT).setSoLinger(0);
 
-        final AtomicReferenceArray<TarantoolClient> clients = new AtomicReferenceArray<TarantoolClient>(numClients);
+        final AtomicReferenceArray<TarantoolClient> clients =
+                new AtomicReferenceArray<>(numClients);
 
         for (int idx = 0; idx < clients.length(); idx++) {
             clients.set(idx, makeClient(provider));
@@ -249,9 +250,7 @@ public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
                 @Override
                 public void run() {
                     while (!Thread.currentThread().isInterrupted() && deadline > System.currentTimeMillis()) {
-
                         int idx = rnd.nextInt(clients.length());
-
                         try {
                             TarantoolClient cli = clients.get(idx);
 
@@ -300,7 +299,7 @@ public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
 
         // Wait for all threads to finish.
         try {
-            assertTrue(latch.await(RESTART_TIMEOUT, TimeUnit.MILLISECONDS));
+            assertTrue(latch.await(RESTART_TIMEOUT * 2, TimeUnit.MILLISECONDS));
         } catch (InterruptedException e) {
             fail(e);
         }


### PR DESCRIPTION
- Avoid a possible race between reading, writing and reconnecting
threads when a reconnection process is started.
It might have happened that the lagged thread (reading or writing) could
reset the state to RECONNECT after the reconnecting thread has already
started and set the state to 0. As a result, all next attempts to
reconnect will never happen. Now the reconnect thread holds on the state
as long as it is required.

- Avoid another possible race between reading and writing threads when
they are started during the reconnection process.
It might have happened that one of the threads crashed when it was
starting and another slightly lagged thread set up its flag. It could
have led that the reconnecting thread saw RECONNECT + R/W state instead
of pure RECONNECT. Again, this case broke down all next reconnection
attempts. Now reading and writing threads take into account whether
RECONNECT state is already set or not.

- Avoid LockSupport class usage for a thread to be suspended and woken
up. Actually, LockSupport is more like an internal component to build
high-level blocking primitives. It is not recommended using this class
directly. It was replaced by ReentrantLock.Condition primitive based
on LockSupport but which has proper LockSupport usage inside.

Fixes: #142
Affects: #34, #136