### PR TITLE
Add support for result set type and concurrency

### DIFF
--- a/src/main/java/org/tarantool/JDBCBridge.java
+++ b/src/main/java/org/tarantool/JDBCBridge.java
@@ -4,30 +4,23 @@ import org.tarantool.protocol.TarantoolPacket;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
 
+@Deprecated
 public class JDBCBridge {
 
     public static final JDBCBridge EMPTY = new JDBCBridge(Collections.emptyList(), Collections.emptyList());
 
-    final List<TarantoolBase.SQLMetaData> sqlMetadata;
-    final Map<String, Integer> columnsByName;
+    final List<SqlProtoUtils.SQLMetaData> sqlMetadata;
     final List<List<Object>> rows;
 
     protected JDBCBridge(TarantoolPacket pack) {
         this(SqlProtoUtils.getSQLMetadata(pack), SqlProtoUtils.getSQLData(pack));
     }
 
-    protected JDBCBridge(List<TarantoolBase.SQLMetaData> sqlMetadata, List<List<Object>> rows) {
+    protected JDBCBridge(List<SqlProtoUtils.SQLMetaData> sqlMetadata, List<List<Object>> rows) {
         this.sqlMetadata = sqlMetadata;
         this.rows = rows;
-        columnsByName = new LinkedHashMap<String, Integer>((int) Math.ceil(sqlMetadata.size() / 0.75), 0.75f);
-        for (int i = 0; i < sqlMetadata.size(); i++) {
-            columnsByName.put(sqlMetadata.get(i).getName(), i + 1);
-        }
     }
 
     public static JDBCBridge query(TarantoolConnection connection, String sql, Object... params) {
@@ -48,9 +41,9 @@ public class JDBCBridge {
      * @return bridge
      */
     public static JDBCBridge mock(List<String> fields, List<List<Object>> values) {
-        List<TarantoolBase.SQLMetaData> meta = new ArrayList<>(fields.size());
+        List<SqlProtoUtils.SQLMetaData> meta = new ArrayList<>(fields.size());
         for (String field : fields) {
-            meta.add(new TarantoolBase.SQLMetaData(field));
+            meta.add(new SqlProtoUtils.SQLMetaData(field));
         }
         return new JDBCBridge(meta, values);
     }
@@ -73,31 +66,18 @@ public class JDBCBridge {
         return rowCount.intValue();
     }
 
-    public String getColumnName(int columnIndex) {
-        return columnIndex > sqlMetadata.size() ? null : sqlMetadata.get(columnIndex - 1).getName();
+    public List<List<Object>> getRows() {
+        return rows;
     }
 
-    public Integer getColumnIndex(String columnName) {
-        return columnsByName.get(columnName);
-    }
-
-    public int getColumnCount() {
-        return columnsByName.size();
-    }
-
-    public ListIterator<List<Object>> iterator() {
-        return rows.listIterator();
-    }
-
-    public int size() {
-        return rows.size();
+    public List<SqlProtoUtils.SQLMetaData> getSqlMetadata() {
+        return sqlMetadata;
     }
 
     @Override
     public String toString() {
         return "JDBCBridge{" +
             "sqlMetadata=" + sqlMetadata +
-            ", columnsByName=" + columnsByName +
             ", rows=" + rows +
             '}';
     }

--- a/src/main/java/org/tarantool/SqlProtoUtils.java
+++ b/src/main/java/org/tarantool/SqlProtoUtils.java
@@ -12,7 +12,7 @@ public abstract class SqlProtoUtils {
         List<List<?>> data = (List<List<?>>) pack.getBody().get(Key.DATA.getId());
 
         List<Map<String, Object>> values = new ArrayList<>(data.size());
-        List<TarantoolBase.SQLMetaData> metaData = getSQLMetadata(pack);
+        List<SQLMetaData> metaData = getSQLMetadata(pack);
         for (List row : data) {
             LinkedHashMap<String, Object> value = new LinkedHashMap<>();
             for (int i = 0; i < row.size(); i++) {
@@ -27,11 +27,11 @@ public abstract class SqlProtoUtils {
         return (List<List<Object>>) pack.getBody().get(Key.DATA.getId());
     }
 
-    public static List<TarantoolBase.SQLMetaData> getSQLMetadata(TarantoolPacket pack) {
+    public static List<SQLMetaData> getSQLMetadata(TarantoolPacket pack) {
         List<Map<Integer, Object>> meta = (List<Map<Integer, Object>>) pack.getBody().get(Key.SQL_METADATA.getId());
-        List<TarantoolBase.SQLMetaData> values = new ArrayList<TarantoolBase.SQLMetaData>(meta.size());
+        List<SQLMetaData> values = new ArrayList<>(meta.size());
         for (Map<Integer, Object> c : meta) {
-            values.add(new TarantoolBase.SQLMetaData((String) c.get(Key.SQL_FIELD_NAME.getId())));
+            values.add(new SQLMetaData((String) c.get(Key.SQL_FIELD_NAME.getId())));
         }
         return values;
     }
@@ -43,5 +43,24 @@ public abstract class SqlProtoUtils {
             return rowCount.longValue();
         }
         return null;
+    }
+
+    public static class SQLMetaData {
+        protected String name;
+
+        public SQLMetaData(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return "SQLMetaData{" +
+                    "name='" + name + '\'' +
+                    '}';
+        }
     }
 }

--- a/src/main/java/org/tarantool/TarantoolBase.java
+++ b/src/main/java/org/tarantool/TarantoolBase.java
@@ -32,25 +32,6 @@ public abstract class TarantoolBase<Result> extends AbstractTarantoolOps<Integer
         }
     }
 
-    protected static class SQLMetaData {
-        protected String name;
-
-        public SQLMetaData(String name) {
-            this.name = name;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public String toString() {
-            return "SQLMetaData{" +
-                "name='" + name + '\'' +
-                '}';
-        }
-    }
-
     protected TarantoolException serverError(long code, Object error) {
         return new TarantoolException(code, error instanceof String ? (String) error : new String((byte[]) error));
     }
@@ -60,7 +41,7 @@ public abstract class TarantoolBase<Result> extends AbstractTarantoolOps<Integer
             try {
                 channel.close();
             } catch (IOException ignored) {
-                // No-op
+                // no-op
             }
         }
     }

--- a/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
+++ b/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
@@ -36,16 +36,16 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
         }
 
         @Override
-        protected Object getRaw(int columnIndex) {
-            return columnIndex > getCurrentRow().size() ? null : getCurrentRow().get(columnIndex - 1);
+        protected Object getRaw(int columnIndex) throws SQLException {
+            List<Object> row = getCurrentRow();
+            return columnIndex > row.size() ? null : row.get(columnIndex - 1);
         }
 
         @Override
-        protected Integer getColumnIndex(String columnLabel) {
-            Integer idx = super.getColumnIndex(columnLabel);
-            return idx == null ? Integer.MAX_VALUE : idx;
+        protected int findColumnIndex(String columnLabel) throws SQLException {
+            int index = super.findColumnIndex(columnLabel);
+            return index == 0 ? Integer.MAX_VALUE : index;
         }
-
 
     }
 
@@ -908,12 +908,13 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public boolean supportsResultSetType(int type) throws SQLException {
-        return false;
+        return type == ResultSet.TYPE_FORWARD_ONLY ||
+            type == ResultSet.TYPE_SCROLL_INSENSITIVE;
     }
 
     @Override
     public boolean supportsResultSetConcurrency(int type, int concurrency) throws SQLException {
-        return false;
+        return supportsResultSetType(type) && concurrency == ResultSet.CONCUR_READ_ONLY;
     }
 
     @Override

--- a/src/main/java/org/tarantool/jdbc/SQLPreparedStatement.java
+++ b/src/main/java/org/tarantool/jdbc/SQLPreparedStatement.java
@@ -239,8 +239,7 @@ public class SQLPreparedStatement extends SQLStatement implements PreparedStatem
     @Override
     public boolean execute() throws SQLException {
         checkNotClosed();
-        discardLastResults();
-        return handleResult(connection.execute(sql, getParams()));
+        return executeInternal(sql, getParams());
     }
 
     @Override

--- a/src/main/java/org/tarantool/jdbc/cursor/CursorIterator.java
+++ b/src/main/java/org/tarantool/jdbc/cursor/CursorIterator.java
@@ -1,0 +1,40 @@
+package org.tarantool.jdbc.cursor;
+
+import java.sql.SQLException;
+
+/**
+ * Extracted interface for a cursor traversal part of {@link java.sql.ResultSet}.
+ */
+public interface CursorIterator<T> {
+
+    boolean isBeforeFirst() throws SQLException;
+
+    boolean isAfterLast() throws SQLException;
+
+    boolean isFirst() throws SQLException;
+
+    boolean isLast() throws SQLException;
+
+    void beforeFirst() throws SQLException;
+
+    void afterLast() throws SQLException;
+
+    boolean first() throws SQLException;
+
+    boolean last() throws SQLException;
+
+    boolean absolute(int row) throws SQLException;
+
+    boolean relative(int rows) throws SQLException;
+
+    boolean next() throws SQLException;
+
+    boolean previous() throws SQLException;
+
+    int getRow() throws SQLException;
+
+    T getItem() throws SQLException;
+
+    void close();
+
+}

--- a/src/main/java/org/tarantool/jdbc/cursor/InMemoryForwardCursorIteratorImpl.java
+++ b/src/main/java/org/tarantool/jdbc/cursor/InMemoryForwardCursorIteratorImpl.java
@@ -1,0 +1,137 @@
+package org.tarantool.jdbc.cursor;
+
+import org.tarantool.util.SQLStates;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  Forward only iterator to support {@link java.sql.ResultSet#TYPE_FORWARD_ONLY}
+ *  result set semantic.
+ */
+public class InMemoryForwardCursorIteratorImpl implements CursorIterator<List<Object>> {
+
+    protected final List<List<Object>> results = new ArrayList<>();
+    protected int currentPosition = -1;
+
+    public InMemoryForwardCursorIteratorImpl(List<List<Object>> results) {
+        if (results == null) {
+            throw new IllegalArgumentException("Results list cannot be null");
+        }
+        this.results.addAll(results);
+    }
+
+    @Override
+    public boolean isBeforeFirst() throws SQLException {
+        return hasResults() && currentPosition == -1;
+    }
+
+    @Override
+    public boolean isAfterLast() throws SQLException {
+        return hasResults() && currentPosition == results.size();
+    }
+
+    @Override
+    public boolean isFirst() throws SQLException {
+        return hasResults() && currentPosition == 0;
+    }
+
+    @Override
+    public boolean isLast() throws SQLException {
+        return hasResults() && currentPosition == results.size() - 1;
+    }
+
+    @Override
+    public void beforeFirst() throws SQLException {
+        throw new SQLException(
+                "Cannot be called on forward only cursor",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    @Override
+    public void afterLast() throws SQLException {
+        throw new SQLException(
+                "Cannot be called on forward only cursor",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    @Override
+    public boolean first() throws SQLException {
+        throw new SQLException(
+                "Cannot be called on forward only cursor",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    @Override
+    public boolean last() throws SQLException {
+        throw new SQLException(
+                "Cannot be called on forward only cursor",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    @Override
+    public boolean absolute(int row) throws SQLException {
+        throw new SQLException(
+                "Cannot be called on forward only cursor",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    @Override
+    public boolean relative(int rows) throws SQLException {
+        throw new SQLException(
+                "Cannot be called on forward only cursor",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    @Override
+    public boolean next() throws SQLException {
+        if (!hasResults() || isAfterLast()) {
+            return false;
+        }
+        currentPosition++;
+        return !isAfterLast();
+    }
+
+    @Override
+    public boolean previous() throws SQLException {
+        throw new SQLException(
+                "Cannot be called on forward only cursor",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    @Override
+    public int getRow() throws SQLException {
+        return !hasResults() || isBeforeFirst() || isAfterLast() ? 0 : currentPosition + 1;
+    }
+
+    @Override
+    public List<Object> getItem() throws SQLException {
+        int row = getRow();
+        if (row > 0) {
+            return results.get(row - 1);
+        }
+        throw new SQLException(
+                "Cursor is out of range. Try to call next() or previous() before.",
+                SQLStates.INVALID_CURSOR_STATE.getSqlState()
+        );
+    }
+
+    protected boolean hasResults() {
+        return !results.isEmpty();
+    }
+
+    @Override
+    public void close() {
+        results.clear();
+        currentPosition = -1;
+    }
+
+}

--- a/src/main/java/org/tarantool/jdbc/cursor/InMemoryScrollableCursorIteratorImpl.java
+++ b/src/main/java/org/tarantool/jdbc/cursor/InMemoryScrollableCursorIteratorImpl.java
@@ -1,0 +1,100 @@
+package org.tarantool.jdbc.cursor;
+
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ *  Scrollable iterator to support {@link java.sql.ResultSet#TYPE_SCROLL_INSENSITIVE}
+ *  result set type semantic.
+ */
+public class InMemoryScrollableCursorIteratorImpl extends InMemoryForwardCursorIteratorImpl {
+
+    public InMemoryScrollableCursorIteratorImpl(List<List<Object>> results) {
+        super(results);
+    }
+
+    @Override
+    public void beforeFirst() throws SQLException {
+        moveIfHasResults(-1);
+    }
+
+    @Override
+    public void afterLast() throws SQLException {
+        moveIfHasResults(results.size());
+    }
+
+    @Override
+    public boolean first() throws SQLException {
+        return moveIfHasResults(0);
+    }
+
+    @Override
+    public boolean last() throws SQLException {
+        return moveIfHasResults(results.size() - 1);
+    }
+
+    @Override
+    public boolean absolute(int row) throws SQLException {
+        if (!hasResults()) {
+            return false;
+        }
+        if (row == 0) {
+            beforeFirst();
+            return false;
+        }
+        if (row > results.size()) {
+            afterLast();
+            return false;
+        }
+        if (row < -results.size()) {
+            beforeFirst();
+            return false;
+        }
+
+        currentPosition = (row > 0) ? row - 1 : results.size() + row;
+        return true;
+    }
+
+    @Override
+    public boolean relative(int rows) throws SQLException {
+        if (!hasResults()) {
+            return false;
+        }
+        if (rows == 0) {
+            return !(isBeforeFirst() || isAfterLast());
+        }
+        if (currentPosition + rows >= results.size()) {
+            afterLast();
+            return false;
+        }
+        if (currentPosition + rows <= -1) {
+            beforeFirst();
+            return false;
+        }
+
+        return absolute(currentPosition + rows + 1);
+    }
+
+    @Override
+    public boolean previous() throws SQLException {
+        if (!hasResults() || isBeforeFirst()) {
+            return false;
+        }
+        currentPosition--;
+        return !isBeforeFirst();
+    }
+
+    /**
+     * Moves to the target position if results is not empty.
+     *
+     * @param position target position
+     * @return successful operation status
+     */
+    private boolean moveIfHasResults(int position) {
+        if (!hasResults()) {
+            return false;
+        }
+        currentPosition = position;
+        return true;
+    }
+}

--- a/src/main/java/org/tarantool/util/SQLStates.java
+++ b/src/main/java/org/tarantool/util/SQLStates.java
@@ -2,8 +2,11 @@ package org.tarantool.util;
 
 public enum SQLStates {
 
+    TOO_MANY_RESULTS("0100E"),
+    NO_DATA("02000"),
+    CONNECTION_DOES_NOT_EXIST("08003"),
     INVALID_PARAMETER_VALUE("22023"),
-    CONNECTION_DOES_NOT_EXIST("08003");
+    INVALID_CURSOR_STATE("24000");
 
     private final String sqlState;
 

--- a/src/test/java/org/tarantool/TestUtils.java
+++ b/src/test/java/org/tarantool/TestUtils.java
@@ -5,10 +5,26 @@ import java.util.List;
 import java.util.Map;
 
 public class TestUtils {
+
     static final String replicationInfoRequest = "return " +
         "box.info.id, " +
         "box.info.lsn, " +
         "box.info.replication";
+
+    @FunctionalInterface
+    public interface ThrowingAction<X extends Throwable> {
+        void run() throws X;
+    }
+
+    public static <X extends Throwable> Runnable throwingWrapper(ThrowingAction<X> action) {
+        return () -> {
+            try {
+                action.run();
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
 
     public static String makeReplicationString(String user, String pass, String... addrs) {
         StringBuilder sb = new StringBuilder();

--- a/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
@@ -202,6 +202,12 @@ public class JdbcPreparedStatementIT extends JdbcTypesIT {
     }
 
     @Test
+    void testStatementConnection() throws SQLException {
+        Statement statement = conn.prepareStatement("SELECT * FROM TEST");
+        assertEquals(conn, statement.getConnection());
+    }
+
+    @Test
     public void testSetByte() throws SQLException {
         makeHelper(Byte.class)
             .setColumns(TntSqlType.INT, TntSqlType.INTEGER)

--- a/src/test/java/org/tarantool/jdbc/JdbcResultSetMetaDataIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcResultSetMetaDataIT.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.sql.ResultSet;
@@ -13,8 +14,11 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+@DisplayName("A resultSet metadata")
 public class JdbcResultSetMetaDataIT extends AbstractJdbcIT {
+
     @Test
+    @DisplayName("returned correct column names")
     public void testColumnNames() throws SQLException {
         Statement stmt = conn.createStatement();
         assertNotNull(stmt);
@@ -36,6 +40,7 @@ public class JdbcResultSetMetaDataIT extends AbstractJdbcIT {
     }
 
     @Test
+    @DisplayName("unwrapped correct")
     public void testUnwrap() throws SQLException {
         try (
                 Statement statement = conn.createStatement();
@@ -48,6 +53,7 @@ public class JdbcResultSetMetaDataIT extends AbstractJdbcIT {
     }
 
     @Test
+    @DisplayName("checked as a proper wrapper")
     public void testIsWrapperFor() throws SQLException {
         try (
                 Statement statement = conn.createStatement();
@@ -58,4 +64,72 @@ public class JdbcResultSetMetaDataIT extends AbstractJdbcIT {
             assertFalse(metaData.isWrapperFor(Integer.class));
         }
     }
+
+    @Test
+    @DisplayName("returned a correct result columns size")
+    public void testColumnCount() throws SQLException {
+        try (Statement statement = conn.createStatement()) {
+            assertNotNull(statement);
+
+            try (ResultSet resultSet = statement.executeQuery("SELECT * FROM test")) {
+                assertNotNull(resultSet);
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                assertEquals(2, metaData.getColumnCount());
+            }
+            try (ResultSet resultSet = statement.executeQuery("SELECT id, val FROM test")) {
+                assertNotNull(resultSet);
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                assertEquals(2, metaData.getColumnCount());
+            }
+            try (ResultSet resultSet = statement.executeQuery("SELECT id FROM test")) {
+                assertNotNull(resultSet);
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                assertEquals(1, metaData.getColumnCount());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("returned correct result column aliases")
+    public void testColumnAliases() throws SQLException {
+        try (Statement statement = conn.createStatement()) {
+            assertNotNull(statement);
+
+            try (ResultSet resultSet = statement.executeQuery("SELECT id AS alias_id FROM test")) {
+                assertNotNull(resultSet);
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                assertEquals("ALIAS_ID", metaData.getColumnLabel(1).toUpperCase());
+            }
+            try (ResultSet resultSet = statement.executeQuery("SELECT val AS alias_val FROM test")) {
+                assertNotNull(resultSet);
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                assertEquals("ALIAS_VAL", metaData.getColumnLabel(1).toUpperCase());
+            }
+            try (ResultSet resultSet = statement.executeQuery("SELECT * FROM test")) {
+                assertNotNull(resultSet);
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                assertEquals("ID", metaData.getColumnLabel(1).toUpperCase());
+                assertEquals("VAL", metaData.getColumnLabel(2).toUpperCase());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("returned an error when column index is out of range")
+    public void testWrongColumnAliases() throws SQLException {
+        try (Statement statement = conn.createStatement()) {
+            assertNotNull(statement);
+
+            try (ResultSet resultSet = statement.executeQuery("SELECT * FROM test")) {
+                assertNotNull(resultSet);
+                ResultSetMetaData metaData = resultSet.getMetaData();
+                int columnsNumber = metaData.getColumnCount();
+                assertThrows(SQLException.class, () -> metaData.getColumnLabel(columnsNumber + 1));
+                assertThrows(SQLException.class, () -> metaData.getColumnLabel(-5));
+                assertThrows(SQLException.class, () -> metaData.getColumnLabel(Integer.MAX_VALUE));
+                assertThrows(SQLException.class, () -> metaData.getColumnLabel(Integer.MIN_VALUE));
+            }
+        }
+    }
+
 }

--- a/src/test/java/org/tarantool/jdbc/JdbcStatementIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcStatementIT.java
@@ -145,4 +145,9 @@ public class JdbcStatementIT extends AbstractJdbcIT {
         }
     }
 
+    @Test
+    void testStatementConnection() throws SQLException {
+        Statement statement = conn.createStatement();
+        assertEquals(conn, statement.getConnection());
+    }
 }

--- a/src/test/java/org/tarantool/jdbc/cursor/AbstractCursorIteratorTest.java
+++ b/src/test/java/org/tarantool/jdbc/cursor/AbstractCursorIteratorTest.java
@@ -1,0 +1,144 @@
+package org.tarantool.jdbc.cursor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *  Minimal iterator use cases should be implemented by every {@link CursorIterator}.
+ */
+public abstract class AbstractCursorIteratorTest {
+
+    protected abstract CursorIterator<List<Object>> getCursorIterator(List<List<Object>> result);
+
+    protected List<List<Object>> makeSingletonListResult(Object... rows) {
+        List<List<Object>> result = new ArrayList<>();
+        for (Object row : rows) {
+            result.add(Collections.singletonList(row));
+        }
+        return result;
+    }
+
+    @Test
+    @DisplayName("failed with a null result object")
+    void testFailIteratorWithNullResult() {
+        assertThrows(IllegalArgumentException.class, () -> new InMemoryForwardCursorIteratorImpl(null));
+    }
+
+    @Test
+    @DisplayName("iterated through an empty result")
+    void testIterationOverEmptyResult() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult();
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertEmpty(iterator);
+
+        for (int i = 0; i < 10; i++) {
+            assertFalse(iterator.next());
+            assertEmpty(iterator);
+        }
+    }
+
+    @Test
+    @DisplayName("iterated through the non-empty results")
+    void testUseCases() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("1");
+        forwardIteratorUseCase(getCursorIterator(result), result);
+
+        result = makeSingletonListResult("1", "2");
+        forwardIteratorUseCase(getCursorIterator(result), result);
+
+        result = makeSingletonListResult("1", "2", "3");
+        forwardIteratorUseCase(getCursorIterator(result), result);
+
+        result = makeSingletonListResult("1", "2", "3", "4", "5", "6", "7", "8", "9");
+        forwardIteratorUseCase(getCursorIterator(result), result);
+    }
+
+    /**
+     * Tests an expected behaviour from a forward iterator.
+     *
+     * @param iterator forward iterator to be tested
+     * @param result   result is backed by <code>iterator</code>
+     */
+    protected void forwardIteratorUseCase(CursorIterator<List<Object>> iterator, List<List<Object>> result)
+            throws SQLException {
+        assertFalse(result.isEmpty());
+
+        assertBeforeFirst(iterator);
+
+        for (int i = 0; i < result.size(); i++) {
+            assertTrue(iterator.next());
+            assertNthPosition(i + 1, iterator, result);
+        }
+
+        assertFalse(iterator.next()); // after last
+        assertAfterLast(iterator);
+
+        for (int i = 0; i < 10; i++) {
+            assertFalse(iterator.next());
+            assertAfterLast(iterator);
+        }
+    }
+
+    protected void assertBeforeFirst(CursorIterator<List<Object>> iterator) throws SQLException {
+        assertTrue(iterator.isBeforeFirst());
+        assertFalse(iterator.isFirst());
+        assertFalse(iterator.isLast());
+        assertFalse(iterator.isAfterLast());
+        assertEquals(0, iterator.getRow());
+        assertThrows(SQLException.class, iterator::getItem);
+    }
+
+    protected void assertAfterLast(CursorIterator<List<Object>> iterator) throws SQLException {
+        assertFalse(iterator.isBeforeFirst());
+        assertFalse(iterator.isFirst());
+        assertFalse(iterator.isLast());
+        assertTrue(iterator.isAfterLast());
+        assertEquals(0, iterator.getRow());
+        assertThrows(SQLException.class, iterator::getItem);
+    }
+
+    protected void assertFirst(CursorIterator<List<Object>> iterator, List<List<Object>> result) throws SQLException {
+        assertFalse(iterator.isBeforeFirst());
+        assertTrue(iterator.isFirst());
+        assertFalse(iterator.isAfterLast());
+        assertEquals(1, iterator.getRow());
+        assertEquals(result.get(0), iterator.getItem());
+    }
+
+    protected void assertLast(CursorIterator<List<Object>> iterator, List<List<Object>> result) throws SQLException {
+        assertFalse(iterator.isBeforeFirst());
+        assertTrue(iterator.isLast());
+        assertFalse(iterator.isAfterLast());
+        assertEquals(result.size(), iterator.getRow());
+        assertEquals(result.get(result.size() - 1), iterator.getItem());
+    }
+
+    protected void assertNthPosition(int position, CursorIterator<List<Object>> iterator, List<List<Object>> result)
+        throws SQLException {
+        assertFalse(iterator.isBeforeFirst());
+        assertFalse(iterator.isAfterLast());
+        assertEquals(position, iterator.getRow());
+        assertEquals(result.get(position - 1), iterator.getItem());
+    }
+
+    protected void assertEmpty(CursorIterator<List<Object>> iterator) throws SQLException {
+        assertFalse(iterator.isBeforeFirst());
+        assertFalse(iterator.isFirst());
+        assertFalse(iterator.isLast());
+        assertFalse(iterator.isAfterLast());
+        assertEquals(0, iterator.getRow());
+        assertThrows(SQLException.class, iterator::getItem);
+    }
+
+}

--- a/src/test/java/org/tarantool/jdbc/cursor/InMemoryForwardCursorIteratorImplTest.java
+++ b/src/test/java/org/tarantool/jdbc/cursor/InMemoryForwardCursorIteratorImplTest.java
@@ -1,0 +1,38 @@
+package org.tarantool.jdbc.cursor;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+
+@DisplayName("A forward iterator")
+class InMemoryForwardCursorIteratorImplTest extends AbstractCursorIteratorTest {
+
+    @Override
+    protected CursorIterator<List<Object>> getCursorIterator(List<List<Object>> result) {
+        return new InMemoryForwardCursorIteratorImpl(result);
+    }
+
+    @Test
+    @DisplayName("failed trying to use unsupported operations")
+    void testUnsupportedOperations() {
+        List<List<Object>> result = makeSingletonListResult("1");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertThrows(SQLException.class, iterator::beforeFirst);
+        assertThrows(SQLException.class, iterator::afterLast);
+        assertThrows(SQLException.class, iterator::first);
+        assertThrows(SQLException.class, iterator::last);
+        assertThrows(SQLException.class, () -> iterator.absolute(0));
+        assertThrows(SQLException.class, () -> iterator.absolute(Integer.MIN_VALUE));
+        assertThrows(SQLException.class, () -> iterator.absolute(Integer.MAX_VALUE));
+        assertThrows(SQLException.class, () -> iterator.relative(0));
+        assertThrows(SQLException.class, () -> iterator.relative(Integer.MIN_VALUE));
+        assertThrows(SQLException.class, () -> iterator.relative(Integer.MAX_VALUE));
+        assertThrows(SQLException.class, iterator::previous);
+    }
+
+}

--- a/src/test/java/org/tarantool/jdbc/cursor/InMemoryScrollableCursorIteratorImplTest.java
+++ b/src/test/java/org/tarantool/jdbc/cursor/InMemoryScrollableCursorIteratorImplTest.java
@@ -1,0 +1,306 @@
+package org.tarantool.jdbc.cursor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.tarantool.TestUtils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+
+@DisplayName("A scrollable iterator")
+class InMemoryScrollableCursorIteratorImplTest extends AbstractCursorIteratorTest {
+
+    @Override
+    protected CursorIterator<List<Object>> getCursorIterator(List<List<Object>> result) {
+        return new InMemoryScrollableCursorIteratorImpl(result);
+    }
+
+    @Test
+    @DisplayName("failed with a null result object")
+    void testFailIteratorWithNullResult() {
+        assertThrows(IllegalArgumentException.class, () -> new InMemoryScrollableCursorIteratorImpl(null));
+    }
+
+    @Test
+    @DisplayName("moved to the last position")
+    void testMoveLast() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertBeforeFirst(iterator);
+        assertTrue(iterator.last());
+        assertLast(iterator, result);
+    }
+
+    @Test
+    @DisplayName("moved to the first position")
+    void testMoveFirst() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertBeforeFirst(iterator);
+        iterator.afterLast();
+        assertAfterLast(iterator);
+        assertTrue(iterator.first());
+        assertFirst(iterator, result);
+    }
+
+    @Test
+    @DisplayName("moved to before the first position")
+    void testMoveBeforeFirst() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertBeforeFirst(iterator);
+        iterator.afterLast();
+        assertAfterLast(iterator);
+        iterator.beforeFirst();
+        assertBeforeFirst(iterator);
+    }
+
+    @Test
+    @DisplayName("moved to after the last position")
+    void testMoveAfterLast() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertBeforeFirst(iterator);
+        iterator.afterLast();
+        assertAfterLast(iterator);
+    }
+
+    @Test
+    @DisplayName("moved to an absolute position")
+    void testMoveAbsolute() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        for (int i = 0; i < result.size(); i++) {
+            assertTrue(iterator.absolute(i + 1));
+            assertNthPosition(i + 1, iterator, result);
+        }
+        for (int i = result.size() + 1; i < result.size() + 10; i++) {
+            assertFalse(iterator.absolute(i));
+            assertAfterLast(iterator);
+        }
+    }
+
+    @Test
+    @DisplayName("moved to a negative absolute position (reverse traversal)")
+    void testMoveNegativeAbsolute() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        for (int i = 0; i < result.size(); i++) {
+            assertTrue(iterator.absolute(-i - 1)); // -1 -2 -3 -4 -5
+            assertNthPosition(5 - i, iterator, result); // 5 4 3 2 1
+        }
+        for (int i = -result.size() - 1; i > -result.size() - 10; i--) {
+            assertFalse(iterator.absolute(i));
+            assertBeforeFirst(iterator);
+        }
+    }
+
+    @Test
+    @DisplayName("moved to a relative position")
+    void testMoveRelative() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertBeforeFirst(iterator);
+        assertTrue(iterator.relative(3)); // before the first -> 3
+        assertNthPosition(3, iterator, result);
+
+        assertTrue(iterator.relative(-2)); // 3 -> 1 (first)
+        assertNthPosition(1, iterator, result);
+
+        assertTrue(iterator.relative(4)); // 1 -> 5 (last)
+        assertNthPosition(5, iterator, result);
+
+        assertTrue(iterator.relative(-3)); // 5 -> 2
+        assertNthPosition(2, iterator, result);
+
+        assertFalse(iterator.relative(-2)); // 2 -> before the first
+        assertBeforeFirst(iterator);
+
+        assertFalse(iterator.relative(0)); // before the first -> before the first
+        assertBeforeFirst(iterator);
+
+        assertFalse(iterator.relative(-2)); // before the first -> before the first
+        assertBeforeFirst(iterator);
+
+        assertTrue(iterator.relative(4)); // before the first -> 4
+        assertNthPosition(4, iterator, result);
+
+        assertFalse(iterator.relative(2)); // 4 -> after the last
+        assertAfterLast(iterator);
+
+        assertTrue(iterator.relative(-3)); // after the last -> 3
+        assertNthPosition(3, iterator, result);
+
+        assertTrue(iterator.relative(0)); // 3 -> 3
+        assertNthPosition(3, iterator, result);
+
+        assertTrue(iterator.relative(1)); // 3 -> 4
+        assertNthPosition(4, iterator, result);
+
+        assertFalse(iterator.relative(5)); // 4 -> after last
+        assertAfterLast(iterator);
+
+        assertTrue(iterator.relative(-4)); // after last -> 2
+        assertNthPosition(2, iterator, result);
+
+        assertFalse(iterator.relative(-3)); // 2 -> before first
+        assertBeforeFirst(iterator);
+    }
+
+    @Test
+    @DisplayName("moved to before the first using absolute navigation")
+    void testMoveAbsoluteZero() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        assertBeforeFirst(iterator);
+        assertTrue(iterator.absolute(3));
+        assertNthPosition(3, iterator, result);
+
+        assertFalse(iterator.absolute(0)); // move to the before the first
+        assertBeforeFirst(iterator);
+    }
+
+    @Test
+    @DisplayName("moved to the same positions using an absolute positioning")
+    void testMoveAbsoluteSimilarities() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> firstIterator = getCursorIterator(result);
+
+        CursorIterator<List<Object>> secondIterator = getCursorIterator(result);
+
+        assertBeforeFirst(firstIterator);
+        assertBeforeFirst(secondIterator);
+
+        // absolute(1) is the same as calling first()
+        firstIterator.absolute(1);
+        secondIterator.first();
+        assertFirst(firstIterator, result);
+        assertFirst(secondIterator, result);
+
+        // absolute(-1) is the same as calling last()
+        firstIterator.absolute(-1);
+        secondIterator.last();
+        assertLast(firstIterator, result);
+        assertLast(secondIterator, result);
+
+        // absolute(0) is the same as calling beforeFirst()
+        firstIterator.absolute(0);
+        secondIterator.beforeFirst();
+        assertBeforeFirst(firstIterator);
+        assertBeforeFirst(secondIterator);
+    }
+
+    @Test
+    @DisplayName("moved to the same positions using an relative positioning")
+    void testMoveRelativeSimilarities() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a", "b", "c", "d", "e");
+        CursorIterator<List<Object>> firstIterator = getCursorIterator(result);
+
+        CursorIterator<List<Object>> secondIterator = getCursorIterator(result);
+
+        assertBeforeFirst(firstIterator);
+        assertBeforeFirst(secondIterator);
+
+        // relative(1) is the same as calling next()
+        for (int i = 0; i < result.size(); i++) {
+            assertTrue(firstIterator.relative(1));
+            assertTrue(secondIterator.next());
+            assertNthPosition(i + 1, firstIterator, result);
+            assertNthPosition(i + 1, secondIterator, result);
+        }
+
+        assertLast(firstIterator, result);
+        assertLast(secondIterator, result);
+
+        // relative(-1) is the same as calling previous()
+        for (int i = result.size(); i > 1; i--) {
+            assertTrue(firstIterator.relative(-1));
+            assertTrue(secondIterator.previous());
+            assertNthPosition(i - 1, firstIterator, result);
+            assertNthPosition(i - 1, secondIterator, result);
+        }
+
+        assertFirst(firstIterator, result);
+        assertFirst(secondIterator, result);
+    }
+
+    @Test
+    @DisplayName("moved to edges over an empty result")
+    void testIterationOverEmptyResult() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult();
+        CursorIterator<List<Object>> iterator = getCursorIterator(result);
+
+        Runnable[] actions = new Runnable[] {
+                TestUtils.throwingWrapper(iterator::beforeFirst),
+                TestUtils.throwingWrapper(iterator::afterLast),
+                TestUtils.throwingWrapper(iterator::first),
+                TestUtils.throwingWrapper(iterator::last),
+                TestUtils.throwingWrapper(iterator::previous),
+                TestUtils.throwingWrapper(() -> iterator.relative(1)),
+                TestUtils.throwingWrapper(() -> iterator.absolute(1)),
+        };
+
+        for (Runnable action : actions) {
+            assertEmpty(iterator);
+            action.run();
+        }
+    }
+
+    @Test
+    @DisplayName("iterated through the non-empty results")
+    void testUseCases() throws SQLException {
+        List<List<Object>> result = makeSingletonListResult("a");
+        backwardIteratorUseCase(getCursorIterator(result), result);
+
+        result = makeSingletonListResult("a", "b");
+        backwardIteratorUseCase(getCursorIterator(result), result);
+
+        result = makeSingletonListResult("a", "b", "c");
+        backwardIteratorUseCase(getCursorIterator(result), result);
+
+        result = makeSingletonListResult("a", "b", "c", "d", "e", "f", "g", "h", "i");
+        backwardIteratorUseCase(getCursorIterator(result), result);
+    }
+
+    /**
+     * Tests an expected behaviour from a scrollable iterator.
+     *
+     * @param iterator scrollable iterator to be tested
+     * @param result   result is backed by <code>iterator</code>
+     */
+    protected void backwardIteratorUseCase(CursorIterator<List<Object>> iterator, List<List<Object>> result)
+            throws SQLException {
+        assertFalse(result.isEmpty());
+
+        assertBeforeFirst(iterator);
+        iterator.afterLast();
+        assertAfterLast(iterator);
+
+        for (int i = result.size() - 1; i >= 0; i--) {
+            assertTrue(iterator.previous());
+            assertNthPosition(i + 1, iterator, result);
+        }
+
+        assertFalse(iterator.previous()); // before first
+        assertBeforeFirst(iterator);
+
+        for (int i = 0; i < 10; i++) {
+            assertFalse(iterator.previous());
+            assertBeforeFirst(iterator);
+        }
+    }
+
+}


### PR DESCRIPTION
Provide support for FORWARD_ONLY and INSENSITIVE scroll types. Now
statements as well as theirs resultSets can be built using a forward
only iterator or full implemented insensitive iterator. To achieve this
iteration logic was extracted into two separate classes to support two
scroll types respectively. This is a cross-cutting support through
SQLMetadata, SQLConnection, SQL(Prepared)Statement, SQLResultSet.

Add support for READ_ONLY concurrency level for a result set.

Extend SQLStates constants in scope of cursors and query execution.
0100E and 02000 for query results; 24000 for cursor iteration support.

Add missed implementation of a closing for SQLStatement and
SQLResultSet.

Deprecate JDBCBridge. This redundant class should be removed completely
in scope of another task. Mapping of field labels was moved to
SQLResultSet.

Closes: #85, #86
Affects: #119, #108