### PR TITLE
Add support for nullsAreSorted* methods group

### DIFF
--- a/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
+++ b/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
@@ -80,22 +80,22 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public boolean nullsAreSortedHigh() throws SQLException {
-        return true;
+        return false;
     }
 
     @Override
     public boolean nullsAreSortedLow() throws SQLException {
-        return !nullsAreSortedHigh();
-    }
-
-    @Override
-    public boolean nullsAreSortedAtStart() throws SQLException {
         return true;
     }
 
     @Override
+    public boolean nullsAreSortedAtStart() throws SQLException {
+        return false;
+    }
+
+    @Override
     public boolean nullsAreSortedAtEnd() throws SQLException {
-        return !nullsAreSortedAtStart();
+        return false;
     }
 
     @Override

--- a/src/test/java/org/tarantool/jdbc/AbstractJdbcIT.java
+++ b/src/test/java/org/tarantool/jdbc/AbstractJdbcIT.java
@@ -38,13 +38,16 @@ public abstract class AbstractJdbcIT {
         "CREATE TABLE test(id INT PRIMARY KEY, val VARCHAR(100))",
         "INSERT INTO test VALUES (1, 'one'), (2, 'two'), (3, 'three')",
         "CREATE TABLE test_compound(id1 INT, id2 INT, val VARCHAR(100), PRIMARY KEY (id2, id1))",
+        "CREATE TABLE test_nulls(id INT PRIMARY KEY, val VARCHAR(100))",
+        "INSERT INTO test_nulls VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, NULL), (5, NULL), (6, NULL)",
         getCreateTableSQL("test_types", TntSqlType.values())
     };
 
     private static String[] cleanSql = new String[] {
         "DROP TABLE IF EXISTS test",
         "DROP TABLE IF EXISTS test_types",
-        "DROP TABLE IF EXISTS test_compound"
+        "DROP TABLE IF EXISTS test_compound",
+        "DROP TABLE IF EXISTS test_nulls"
     };
 
     protected static TarantoolControl control;

--- a/src/test/java/org/tarantool/jdbc/JdbcDatabaseMetaDataIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcDatabaseMetaDataIT.java
@@ -51,6 +51,9 @@ public class JdbcDatabaseMetaDataIT extends AbstractJdbcIT {
         assertEquals("TEST_COMPOUND", rs.getString("TABLE_NAME"));
 
         assertTrue(rs.next());
+        assertEquals("TEST_NULLS", rs.getString("TABLE_NAME"));
+
+        assertTrue(rs.next());
         assertEquals("TEST_TYPES", rs.getString("TABLE_NAME"));
 
         assertFalse(rs.next());
@@ -272,4 +275,12 @@ public class JdbcDatabaseMetaDataIT extends AbstractJdbcIT {
         assertFalse(meta.supportsGetGeneratedKeys());
     }
 
+    @Test
+    public void testNullsAreSortedProperties() throws SQLException {
+        assertTrue(meta.nullsAreSortedLow());
+        assertFalse(meta.nullsAreSortedHigh());
+
+        assertFalse(meta.nullsAreSortedAtStart());
+        assertFalse(meta.nullsAreSortedAtEnd());
+    }
 }

--- a/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
@@ -3,6 +3,7 @@ package org.tarantool.jdbc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,6 +18,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 public class JdbcResultSetIT extends JdbcTypesIT {
+
     private Statement stmt;
     private DatabaseMetaData metaData;
 
@@ -146,6 +148,34 @@ public class JdbcResultSetIT extends JdbcTypesIT {
         ResultSet resultSet = stmt.executeQuery("SELECT * FROM test WHERE id < 0");
         assertTrue(resultSet.isWrapperFor(SQLResultSet.class));
         assertFalse(resultSet.isWrapperFor(Integer.class));
+    }
+
+    @Test
+    public void testNullsSortingAsc() throws SQLException {
+        ResultSet resultSet = stmt.executeQuery("SELECT * FROM test_nulls ORDER BY val ASC");
+        for (int i = 0; i < 3; i++) {
+            assertTrue(resultSet.next());
+            assertNull(resultSet.getString(2));
+        }
+        for (int i = 0; i < 3; i++) {
+            assertTrue(resultSet.next());
+            assertNotNull(resultSet.getString(2));
+        }
+        assertFalse(resultSet.next());
+    }
+
+    @Test
+    public void testNullsSortingDesc() throws SQLException {
+        ResultSet resultSet = stmt.executeQuery("SELECT * FROM test_nulls ORDER BY val DESC");
+        for (int i = 0; i < 3; i++) {
+            assertTrue(resultSet.next());
+            assertNotNull(resultSet.getString(2));
+        }
+        for (int i = 0; i < 3; i++) {
+            assertTrue(resultSet.next());
+            assertNull(resultSet.getString(2));
+        }
+        assertFalse(resultSet.next());
     }
 
 }


### PR DESCRIPTION
Add support for nullsAreSortedLow as a default sorting which is provided
by Tarantool DB.

Fixes: #120