### PR TITLE
Support Connection.isValid method

### DIFF
--- a/src/test/java/org/tarantool/jdbc/JdbcConnectionIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcConnectionIT.java
@@ -115,6 +115,15 @@ public class JdbcConnectionIT extends AbstractJdbcIT {
     }
 
     @Test
+    void testIsValidCheck() throws SQLException {
+        assertTrue(conn.isValid(2000));
+        assertThrows(SQLException.class, () -> conn.isValid(-1000));
+
+        conn.close();
+        assertFalse(conn.isValid(2000));
+    }
+
+    @Test
     public void testConnectionUnwrap() throws SQLException {
         assertEquals(conn, conn.unwrap(SQLConnection.class));
         assertThrows(SQLException.class, () -> conn.unwrap(Integer.class));


### PR DESCRIPTION
Add ping request to the DB using `SELECT 1` expression. Timeout requires
the implementation of at least Statement.setQueryTimeout and
Statement.cancel (see #155 ).

Closes: #75
Depends on: #155