### PR TITLE
Improve awaiting Tarantool start/stop processes

### DIFF
--- a/src/test/java/org/tarantool/AbstractTarantoolConnectorIT.java
+++ b/src/test/java/org/tarantool/AbstractTarantoolConnectorIT.java
@@ -235,12 +235,10 @@ public abstract class AbstractTarantoolConnectorIT {
 
     protected static void stopTarantool(String instance) {
         control.stop(instance);
-        control.waitStopped("jdk-testing");
     }
 
     protected static void startTarantool(String instance) {
         control.start(instance);
-        control.waitStarted("jdk-testing");
     }
 
     /**

--- a/src/test/java/org/tarantool/AbstractTarantoolSQLConnectorIT.java
+++ b/src/test/java/org/tarantool/AbstractTarantoolSQLConnectorIT.java
@@ -131,12 +131,10 @@ public abstract class AbstractTarantoolSQLConnectorIT {
 
     protected static void stopTarantool(String instance) {
         control.stop(instance);
-        control.waitStopped("jdk-testing");
     }
 
     protected static void startTarantool(String instance) {
         control.start(instance);
-        control.waitStarted("jdk-testing");
     }
 
 }

--- a/src/test/java/org/tarantool/ClientReconnectClusterIT.java
+++ b/src/test/java/org/tarantool/ClientReconnectClusterIT.java
@@ -36,8 +36,8 @@ public class ClientReconnectClusterIT {
     private static final String SRV1 = "replica1";
     private static final String SRV2 = "replica2";
     private static final String SRV3 = "replica3";
-    private static final int[] PORTS = { 3302, 3303, 3304 };
-    private static final int[] CONSOLE_PORTS = { 3312, 3313, 3314 };
+    private static final int[] PORTS = { 3401, 3402, 3403 };
+    private static final int[] CONSOLE_PORTS = { 3501, 3502, 3503 };
     private static TarantoolControl control;
 
     private static String REPLICATION_CONFIG = TestUtils.makeReplicationString(
@@ -410,7 +410,7 @@ public class ClientReconnectClusterIT {
 
     private void startInstancesAndAwait(String... instances) {
         for (String instance : instances) {
-            control.start(instance);
+            control.start(instance, false);
         }
         for (String instance : instances) {
             control.waitStarted(instance);
@@ -420,9 +420,6 @@ public class ClientReconnectClusterIT {
     private void stopInstancesAndAwait(String... instances) {
         for (String instance : instances) {
             control.stop(instance);
-        }
-        for (String instance : instances) {
-            control.waitStopped(instance);
         }
     }
 

--- a/src/test/java/org/tarantool/ClientReconnectIT.java
+++ b/src/test/java/org/tarantool/ClientReconnectIT.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.LockSupport;
 
 public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
+
     private static final String INSTANCE_NAME = "jdk-testing";
     private TarantoolClient client;
 
@@ -99,7 +100,7 @@ public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
         client.syncOps().ping();
 
         // The park() will return inside connector thread.
-        LockSupport.unpark(((TarantoolClientImpl)client).connector);
+        LockSupport.unpark(((TarantoolClientImpl) client).connector);
 
         // Wait on latch as a proof that reconnect did not happen.
         // In case of a failure, latch will reach 0 before timeout occurs.
@@ -213,11 +214,54 @@ public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
         });
     }
 
+    // DO NOT REMOVE THIS TEST
+    // Motivation: this test checks start/stop correctness
+    // of TarantoolControl class which is used by other tests.
+    // This test is commented out because the class is used
+    // for internal purposes only and isn't related to
+    // the connector testing.
+    //    @Test
+    //    @DisplayName("follow up the issue #164")
+    //    void testStartStopTarantoolInstance() throws InterruptedException {
+    //        int numberOfParallelInstances = 4;
+    //        CountDownLatch finished = new CountDownLatch(numberOfParallelInstances);
+    //        List<String> instancesNames = new ArrayList<>(numberOfParallelInstances);
+    //
+    //        for (int i = 0; i < numberOfParallelInstances; i++) {
+    //            String instance = "startStop" + (i + 1);
+    //            instancesNames.add(instance);
+    //            control.createInstance(
+    //                instancesNames.get(i),
+    //                LUA_FILE,
+    //                makeInstanceEnv(3401 + i + 1, 3501 + i + 1)
+    //            );
+    //            startTarantool(instancesNames.get(i));
+    //            new Thread(() -> {
+    //                for (int j = 0; j < 100; j++) {
+    //                    stopTarantool(instance);
+    //                    startTarantool(instance);
+    //                    if (j % 10 == 0) {
+    //                        System.out.println(
+    //                            Thread.currentThread().getName() + ": " + j + "% completed"
+    //                        );
+    //                    }
+    //                }
+    //                finished.countDown();
+    //            }, "Thread" + (i + 1)).start();
+    //        }
+    //
+    //        assertTrue(finished.await(2, TimeUnit.MINUTES));
+    //
+    //        for (int i = 0; i < numberOfParallelInstances; i++) {
+    //            stopTarantool(instancesNames.get(i));
+    //        }
+    //    }
+
     /**
      * Test concurrent operations, reconnects and close.
-     *
+     * <p>
      * Expected situation is nothing gets stuck.
-     *
+     * <p>
      * The test sets SO_LINGER to 0 for outgoing connections to avoid producing
      * many TIME_WAIT sockets, because an available port range can be
      * exhausted.
@@ -316,7 +360,7 @@ public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
      * Verify that we don't exceed a file descriptor limit (and so likely don't
      * leak file descriptors) when trying to connect to an existing node with
      * wrong authentification credentials.
-     *
+     * <p>
      * The test sets SO_LINGER to 0 for outgoing connections to avoid producing
      * many TIME_WAIT sockets, because an available port range can be
      * exhausted.
@@ -354,4 +398,5 @@ public class ClientReconnectIT extends AbstractTarantoolConnectorIT {
         client.syncOps().ping();
         client.close();
     }
+
 }

--- a/src/test/java/org/tarantool/TarantoolControl.java
+++ b/src/test/java/org/tarantool/TarantoolControl.java
@@ -8,16 +8,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Wrapper around tarantoolctl utility.
  */
 public class TarantoolControl {
-    public class TarantoolControlException extends RuntimeException {
+
+    public static class TarantoolControlException extends RuntimeException {
+
         int code;
         String stdout;
         String stderr;
@@ -32,6 +37,7 @@ public class TarantoolControl {
             this.stdout = stdout;
             this.stderr = stderr;
         }
+
     }
 
     protected static final String tntCtlWorkDir = System.getProperty("tntCtlWorkDir",
@@ -127,75 +133,61 @@ public class TarantoolControl {
     }
 
     /**
-     * Control the given tarantool instance via tarantoolctl utility.
+     * Executes a command of the given tarantool instance via
+     * tarantoolctl utility.
      *
-     * @param command A tarantoolctl utility command.
-     * @param instanceName Name of tarantool instance to control.
+     * @param command      tarantoolctl utility command.
+     * @param instanceName name of tarantool instance to control.
      */
-    protected void executeCommand(String command, String instanceName) {
-        ProcessBuilder builder = new ProcessBuilder("env", "tarantoolctl", command, instanceName);
-        builder.directory(new File(tntCtlWorkDir));
-        Map<String, String> env = builder.environment();
-        env.putAll(buildInstanceEnvironment(instanceName));
-
-        final Process process;
-        try {
-            process = builder.start();
-        } catch (IOException e) {
-            throw new RuntimeException("environment failure", e);
-        }
-
-        final CountDownLatch latch = new CountDownLatch(1);
-        // The thread below is necessary to organize timed wait on the process.
-        // We cannot use Process.waitFor(long, TimeUnit) because we're on java 6.
-        Thread thread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    process.waitFor();
-                } catch (InterruptedException ignored) {
-                    // no-op.
-                }
-                latch.countDown();
-            }
-        });
-
-        thread.start();
-
-        boolean res;
-        try {
-            res = latch.await(RESTART_TIMEOUT, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            throw new RuntimeException("wait interrupted", e);
-        }
-
-        if (!res) {
-            thread.interrupt();
-            process.destroy();
-
-            throw new RuntimeException("timeout");
-        }
-
-        int code = process.exitValue();
-
-        if (code != 0) {
-            String stdout = "";
-            String stderr = "";
-            try {
-                stdout = loadStream(process.getInputStream());
-                stderr = loadStream(process.getErrorStream());
-            } catch (IOException ignored) {
-                /* no-op. */
-            }
-            throw new TarantoolControlException(code, stdout, stderr);
+    protected void executeControlCommand(String command, String instanceName) {
+        ProcessCommand controlCommand =
+            new ProcessCommand(buildInstanceEnvironment(instanceName), "env", "tarantoolctl", command, instanceName);
+        if (!controlCommand.execute()) {
+            throw new TarantoolControlException(
+                controlCommand.getExitCode(),
+                controlCommand.getOutput(),
+                controlCommand.getError()
+            );
         }
     }
 
     /**
-     * Wait until the instance will be started.
+     * Sends <code>start</code> command using tarantoolctl
+     * and blocks until the process will be up.
+     * <p>
+     * Calling this method has the same effect as
+     * {@code start(instanceName, true)}
      *
+     * @param instanceName target instance name
+     *
+     * @see #start(String, boolean)
+     */
+    public void start(String instanceName) {
+        start(instanceName, true);
+    }
+
+    /**
+     * Sends <code>start</code> command using tarantoolctl
+     * and optionally blocks until the process will be up.
+     * <p>
+     * The block includes real connection establishment using
+     * {@link org.tarantool.TarantoolConsole}.
+     *
+     * @param instanceName target instance name
+     * @see #waitStarted(String)
+     */
+    public void start(String instanceName, boolean wait) {
+        executeControlCommand("start", instanceName);
+        if (wait) {
+            waitStarted(instanceName);
+        }
+    }
+
+    /**
+     * Waits until the instance will be started.
+     * <p>
      * Use tarantoolctl status instanceName.
-     *
+     * <p>
      * Then test the instance with TarantoolTcpConsole (ADMIN environment
      * variable is set) or TarantoolLocalConsole.
      */
@@ -216,36 +208,54 @@ public class TarantoolControl {
     }
 
     /**
-     * Wait until the instance will be stopped.
+     * Sends <code>stop</code> command using tarantoolctl
+     * and blocks until the process will be down.
      *
-     * Use tarantoolctl status instanceName.
+     * @param instanceName target instance name
      */
-    public void waitStopped(String instanceName) {
-        while (status(instanceName) != 1) {
+    public void stop(String instanceName) {
+        try {
+            Path path = Paths.get(tntCtlWorkDir, instanceName + ".pid");
+            if (Files.exists(path)) {
+                String pid = new String(Files.readAllBytes(path));
+                executeControlCommand("stop", instanceName);
+                waitStopped(pid, instanceName);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Waits until the instance will be stopped.
+     *
+     * @param pid          instance PID
+     * @param instanceName target instance name
+     */
+    private void waitStopped(String pid, String instanceName) {
+        while (status(instanceName) != 1 || isProcessAlive(pid)) {
             sleep();
         }
     }
 
-    public void start(String instanceName) {
-        executeCommand("start", instanceName);
-    }
-
-    public void stop(String instanceName) {
-        executeCommand("stop", instanceName);
+    private boolean isProcessAlive(String pid) {
+        ProcessCommand sendSignal0Command =
+            new ProcessCommand(Collections.emptyMap(), "kill", "-0", pid);
+        return sendSignal0Command.execute();
     }
 
     /**
      * Wrapper for `tarantoolctl status instanceName`.
-     *
+     * <p>
      * Return exit code of the command:
-     *
+     * <p>
      * * 0 -- started;
      * * 1 -- stopped;
      * * 2 -- pid file exists, control socket inaccessible.
      */
     public int status(String instanceName) {
         try {
-            executeCommand("status", instanceName);
+            executeControlCommand("status", instanceName);
         } catch (TarantoolControlException e) {
             return e.code;
         }
@@ -253,7 +263,7 @@ public class TarantoolControl {
         return 0;
     }
 
-    public Map<String,String> buildInstanceEnvironment(String instanceName) {
+    public Map<String, String> buildInstanceEnvironment(String instanceName) {
         Map<String, String> env = new HashMap<String, String>();
         env.put("PWD", tntCtlWorkDir);
         env.put("TEST_WORKDIR", tntCtlWorkDir);
@@ -321,7 +331,7 @@ public class TarantoolControl {
         } else {
             int idx = admin.indexOf(':');
             return TarantoolConsole.open(idx < 0 ? "localhost" : admin.substring(0, idx),
-                 Integer.valueOf(idx < 0 ? admin : admin.substring(idx + 1)));
+                Integer.valueOf(idx < 0 ? admin : admin.substring(idx + 1)));
         }
     }
 
@@ -332,4 +342,67 @@ public class TarantoolControl {
             throw new RuntimeException(e);
         }
     }
+
+    static class ProcessCommand {
+
+        final ProcessBuilder processBuilder;
+
+        String lastOutput = "";
+        String lastError = "";
+        int lastExitCode = -1;
+
+        public ProcessCommand(Map<String, String> environment, String... commands) {
+            processBuilder = new ProcessBuilder(commands);
+            processBuilder.directory(new File(tntCtlWorkDir));
+            Map<String, String> env = processBuilder.environment();
+            env.putAll(environment);
+        }
+
+        boolean execute() {
+            final Process process;
+            try {
+                process = processBuilder.start();
+            } catch (IOException e) {
+                throw new RuntimeException("environment failure", e);
+            }
+
+            boolean res;
+            try {
+                res = process.waitFor(RESTART_TIMEOUT, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("wait interrupted", e);
+            }
+
+            if (!res) {
+                process.destroy();
+                throw new RuntimeException("timeout");
+            }
+
+            lastExitCode = process.exitValue();
+            try {
+                lastOutput = loadStream(process.getInputStream()).trim();
+                lastError = loadStream(process.getErrorStream()).trim();
+            } catch (IOException ignored) {
+                lastOutput = "";
+                lastError = "";
+            }
+
+            return lastExitCode == 0;
+        }
+
+        String getOutput() {
+            return lastOutput;
+        }
+
+        String getError() {
+            return lastError;
+        }
+
+        int getExitCode() {
+            return lastExitCode;
+        }
+
+    }
+
 }
+

--- a/src/test/java/org/tarantool/cluster/ClusterServiceStoredFunctionDiscovererIT.java
+++ b/src/test/java/org/tarantool/cluster/ClusterServiceStoredFunctionDiscovererIT.java
@@ -47,7 +47,6 @@ public class ClusterServiceStoredFunctionDiscovererIT {
         control.createInstance(INSTANCE_NAME, LUA_FILE, makeInstanceEnv(INSTANCE_LISTEN_PORT, INSTANCE_ADMIN_PORT));
 
         control.start(INSTANCE_NAME);
-        control.waitStarted(INSTANCE_NAME);
     }
 
     @BeforeEach
@@ -61,7 +60,6 @@ public class ClusterServiceStoredFunctionDiscovererIT {
     @AfterAll
     public static void tearDownEnv() {
         control.stop(INSTANCE_NAME);
-        control.waitStopped(INSTANCE_NAME);
     }
 
     @Test

--- a/src/test/java/org/tarantool/jdbc/AbstractJdbcIT.java
+++ b/src/test/java/org/tarantool/jdbc/AbstractJdbcIT.java
@@ -58,7 +58,6 @@ public abstract class AbstractJdbcIT {
         control = new TarantoolControl();
         control.createInstance("jdk-testing", LUA_FILE, makeInstanceEnv(LISTEN, ADMIN));
         control.start("jdk-testing");
-        control.waitStarted("jdk-testing");
 
         sqlExec(cleanSql);
         sqlExec(initSql);
@@ -70,7 +69,6 @@ public abstract class AbstractJdbcIT {
             sqlExec(cleanSql);
         } finally {
             control.stop("jdk-testing");
-            control.waitStopped("jdk-testing");
         }
     }
 


### PR DESCRIPTION
Add await-versions of start/stop commands for TarantoolControl class.
Improve the waiting process with an extra monitoring PID of a running
Tarantool-instance using terminal ps-command.

Fixes: #164