### PR TITLE
add java8(12) build to travis (and remove oracle java11 and java10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ jobs:
       script: mvn checkstyle:check
       after_success: skip
     - stage: test
-      jdk: oraclejdk11
-    - stage: test
-      jdk: openjdk10
+      jdk: openjdk8
     - stage: test
       jdk: openjdk11
+    - stage: test
+      jdk: openjdk12
 
 before_script:
   - .travis/travis.pre.sh


### PR DESCRIPTION
Java8 will be used for years - it is crucial to support it. Java10 is EOL-ed and is not supported by any vendor. Java11 updates from Oracle are not free and there is no need to test against some old version if there is a check against most recent Openjdk11.

Also added Java12 to the build - it is not LTS and hardly will be used by anyone, but it is better to catch problems with new versions of java early - in half a year it will be worth replacing it with Java13