### PR TITLE
Socket provider retry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get the Java connector for Tarantool 1.6.9, visit
 
 ## Getting started
 
-1. Add a dependency to your `pom.xml` file.
+1. Add a dependency to your `pom.xml` file:
 
 ```xml
 <dependency>
@@ -32,7 +32,7 @@ To get the Java connector for Tarantool 1.6.9, visit
 </dependency>
 ```
 
-2. Configure `TarantoolClientConfig`.
+2. Configure `TarantoolClientConfig`:
 
 ```java
 TarantoolClientConfig config = new TarantoolClientConfig();
@@ -40,66 +40,72 @@ config.username = "test";
 config.password = "test";
 ```
 
-3. Implement your `SocketChannelProvider`.
-   It should return a connected `SocketChannel`.
+3. Create a client:
 
 ```java
-SocketChannelProvider socketChannelProvider = new SocketChannelProvider() {
-           @Override
-           public SocketChannel get(int retryNumber, Throwable lastError) {
-               if (lastError != null) {
-                   lastError.printStackTrace(System.out);
-               }
-               try {
-                   return SocketChannel.open(new InetSocketAddress("localhost", 3301));
-               } catch (IOException e) {
-                   throw new IllegalStateException(e);
-               }
-           }
-       };
+TarantoolClient client = new TarantoolClientImpl("host:3301", config);
 ```
 
-Here you could also implement some reconnection or fallback policy.
-Remember that `TarantoolClient` adopts a
-[fail-fast](https://en.wikipedia.org/wiki/Fail-fast) policy
-when a client is not connected.
+using `TarantoolClientImpl(String, TarantoolClientConfig)` is equivalent to:
 
-The `TarantoolClient` will stop functioning if your implementation of a socket
-channel provider raises an exception or returns a null. You will need a new
-instance of client to recover. Hence, you should only throw in case you have
-met unrecoverable error.
+```java
+SocketChannelProvider socketChannelProvider = new SingleSocketChannelProviderImpl("host:3301")
+TarantoolClient client = new TarantoolClientImpl(socketChannelProvider, config);
+```
 
-Below is an example of `SocketChannelProvider` implementation that handles short
-tarantool restarts.
+You could implement your own `SocketChannelProvider`. It should return 
+a connected `SocketChannel`. Feel free to implement `get(int retryNumber, Throwable lastError)`
+using your appropriate strategy to obtain the channel. The strategy can take into
+account current attempt number (retryNumber) and the last transient error occurred on
+the previous attempt.
+
+The `TarantoolClient` will be closed if your implementation of a socket
+channel provider raises exceptions. However, throwing a `SocketProviderTransientException`
+or returning `null` value are handled by the client as recoverable errors. In these cases,
+the client will make next attempt to obtain the socket channel. Otherwise, you will need
+a new instance of client to recover. Hence, you should only throw an error different
+to `SocketProviderTransientException` in case you have met unrecoverable error.
+
+Below is an example of `SocketChannelProvider` implementation that tries
+to connect no more than 3 times, two seconds for each attempt at max.
 
 ```java
 SocketChannelProvider socketChannelProvider = new SocketChannelProvider() {
     @Override
     public SocketChannel get(int retryNumber, Throwable lastError) {
-        long deadline = System.currentTimeMillis() + RESTART_TIMEOUT;
-        while (!Thread.currentThread().isInterrupted()) {
-            try {
-                return SocketChannel.open(new InetSocketAddress("localhost", 3301));
-            } catch (IOException e) {
-                if (deadline < System.currentTimeMillis())
-                    throw new RuntimeException(e);
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException ignored) {
-                    Thread.currentThread().interrupt();
-                }
-            }
+        if (retryNumber > 3) {
+            throw new RuntimeException("Too many attempts");
         }
-        throw new RuntimeException(new TimeoutException("Connect timed out."));
+        SocketChannel channel = null;
+        try {
+            channel = SocketChannel.open();
+            channel.socket().connect(new InetSocketAddress("localhost", 3301), 2000);
+            return channel;
+        } catch (IOException e) {
+            if (channel != null) {
+                 try {
+                     channel.close();
+                 } catch (IOException ignored) { }
+            }
+            throw new SocketProviderTransientException("Couldn't connect to server", e);
+        }
     }
 };
 ```
 
-4. Create a client.
+Same behaviour can be achieved using built-in `SingleSocketChannelProviderImpl`:
 
 ```java
+TarantoolClientConfig config = new TarantoolClientConfig();
+config.connectionTimeout = 2_000; // two seconds timeout per attempt
+config.retryCount = 3;            // three attempts at max
+
+SocketChannelProvider socketChannelProvider = new SingleSocketChannelProviderImpl("localhost:3301")
 TarantoolClient client = new TarantoolClientImpl(socketChannelProvider, config);
 ```
+
+`SingleSocketChannelProviderImpl` implements `ConfigurableSocketChannelProvider` that
+makes possible for the client to configure a socket provider.
 
 > **Notes:**
 > * `TarantoolClient` is thread-safe and asynchronous, so you should use one
@@ -168,6 +174,21 @@ a list of nodes which will be used by the cluster client to provide such
 ability. Also you can prefer to use a [discovery mechanism](#auto-discovery)
 in order to dynamically fetch and apply the node list.
 
+### The RoundRobinSocketProviderImpl class
+
+This cluster-aware provider uses addresses pool to connect to DB server.
+The provider picks up next address in order the addresses were passed.
+
+Similar to `SingleSocketChannelProviderImpl` this RR provider also
+relies on two options from the config: `TarantoolClientConfig.connectionTimeout`
+and `TarantoolClientConfig.retryCount` but in a bit different way.
+The latter option says how many times the provider should try to establish a
+connection to _one instance_ before failing an attempt. The provider requires
+positive retry count to work properly. The socket timeout is used to limit
+an interval between connections attempts per instance. In other words, the provider
+follows a pattern _connection should succeed after N attempts with M interval between
+them at max_. 
+
 ### Basic cluster client usage
 
 1. Configure `TarantoolClusterClientConfig`:
@@ -198,7 +219,7 @@ client.syncOps().insert(23, Arrays.asList(1, 1));
 Auto-discovery feature allows a cluster client to fetch addresses of 
 cluster nodes to reflect changes related to the cluster topology. To achieve
 this you have to create a Lua function on the server side which returns 
-a single array result. Client periodically pools the server to obtain a 
+a single array result. Client periodically polls the server to obtain a 
 fresh list and apply it if its content changes.
 
 1. On the server side create a function which returns nodes:

--- a/src/main/java/org/tarantool/ConfigurableSocketChannelProvider.java
+++ b/src/main/java/org/tarantool/ConfigurableSocketChannelProvider.java
@@ -1,0 +1,23 @@
+package org.tarantool;
+
+public interface ConfigurableSocketChannelProvider extends SocketChannelProvider {
+
+    int RETRY_NO_LIMIT = 0;
+    int NO_TIMEOUT = 0;
+
+    /**
+     * Configures max count of retries.
+     *
+     * @param limit max attempts count
+     */
+    void setRetriesLimit(int limit);
+
+    /**
+     * Configures max time to establish
+     * a connection per attempt.
+     *
+     * @param timeout connection timeout in millis
+     */
+    void setConnectionTimeout(int timeout);
+
+}

--- a/src/main/java/org/tarantool/SingleSocketChannelProviderImpl.java
+++ b/src/main/java/org/tarantool/SingleSocketChannelProviderImpl.java
@@ -5,6 +5,7 @@ import org.tarantool.util.StringUtils;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.channels.SocketChannel;
 
 /**
  * Simple provider that produces a single connection.
@@ -28,8 +29,26 @@ public class SingleSocketChannelProviderImpl extends BaseSocketChannelProvider {
     }
 
     @Override
-    protected InetSocketAddress getAddress(int retryNumber, Throwable lastError) throws IOException {
-        return address;
+    protected SocketChannel makeAttempt(int retryNumber, Throwable lastError) throws IOException {
+        if (areRetriesExhausted(retryNumber)) {
+            throw new CommunicationException("Connection retries exceeded.", lastError);
+        }
+        return openChannel(address);
+    }
+
+    /**
+     * Provides a decision on whether retries limit is hit.
+     *
+     * @param retryNumber current count of retries.
+     *
+     * @return {@code true} if retries are exhausted.
+     */
+    private boolean areRetriesExhausted(int retryNumber) {
+        int limit = getRetriesLimit();
+        if (limit < 1) {
+            return false;
+        }
+        return retryNumber >= limit;
     }
 
     public void setAddress(String address) {

--- a/src/main/java/org/tarantool/SocketChannelProvider.java
+++ b/src/main/java/org/tarantool/SocketChannelProvider.java
@@ -1,18 +1,22 @@
 package org.tarantool;
 
+import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 
 public interface SocketChannelProvider {
 
-    int RETRY_NO_LIMIT = -1;
-    int NO_TIMEOUT = 0;
-
     /**
      * Provides socket channel to init restore connection.
-     * You could change hosts on fail and sleep between retries in this method
-     * @param retryNumber number of current retry. Reset after successful connect.
+     * You could change hosts between retries in this method.
+     *
+     * @param retryNumber number of current retry.
      * @param lastError   the last error occurs when reconnecting
-     * @return the result of SocketChannel open(SocketAddress remote) call
+     *
+     * @return the result of {@link SocketChannel#open(SocketAddress)} call
+     *
+     * @throws SocketProviderTransientException if recoverable error occurred
+     * @throws RuntimeException                 if any other reasons occurred
      */
     SocketChannel get(int retryNumber, Throwable lastError);
+
 }

--- a/src/main/java/org/tarantool/SocketProviderTransientException.java
+++ b/src/main/java/org/tarantool/SocketProviderTransientException.java
@@ -1,0 +1,9 @@
+package org.tarantool;
+
+public class SocketProviderTransientException extends RuntimeException {
+
+    public SocketProviderTransientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/tarantool/TarantoolClientConfig.java
+++ b/src/main/java/org/tarantool/TarantoolClientConfig.java
@@ -37,15 +37,34 @@ public class TarantoolClientConfig {
     public double directWriteFactor = 0.5d;
 
     /**
+     * Write operation timeout.
+     */
+    public long writeTimeoutMillis = 60 * 1000L;
+
+    /**
      * Use old call command https://github.com/tarantool/doc/issues/54,
      * please ensure that you server supports new call command.
      */
     public boolean useNewCall = false;
 
     /**
-     * Limits for synchronous operations.
+     *  Max time to establish connection to the server
+     *  and be completely configured (to have an {@code ALIVE} status).
+     *
+     * @see TarantoolClient#isAlive()
      */
     public long initTimeoutMillis = 60 * 1000L;
-    public long writeTimeoutMillis = 60 * 1000L;
+
+    /**
+     * Connection timeout per attempt.
+     * {@code 0} means no timeout.
+     */
+    public int connectionTimeout = 2 * 1000;
+
+    /**
+     * Total attempts number to connect to DB.
+     * {@code 0} means unlimited attempts.
+     */
+    public int retryCount = 3;
 
 }

--- a/src/main/java/org/tarantool/TarantoolClusterClient.java
+++ b/src/main/java/org/tarantool/TarantoolClusterClient.java
@@ -52,7 +52,7 @@ public class TarantoolClusterClient extends TarantoolClientImpl {
      * @param addresses Array of addresses in the form of host[:port].
      */
     public TarantoolClusterClient(TarantoolClusterClientConfig config, String... addresses) {
-        this(config, makeClusterSocketProvider(addresses, config.operationExpiryTimeMillis));
+        this(config, makeClusterSocketProvider(addresses));
     }
 
     /**
@@ -268,11 +268,8 @@ public class TarantoolClusterClient extends TarantoolClientImpl {
         }
     }
 
-    private static RoundRobinSocketProviderImpl makeClusterSocketProvider(String[] addresses,
-                                                                          int connectionTimeout) {
-        RoundRobinSocketProviderImpl socketProvider = new RoundRobinSocketProviderImpl(addresses);
-        socketProvider.setTimeout(connectionTimeout);
-        return socketProvider;
+    private static RoundRobinSocketProviderImpl makeClusterSocketProvider(String[] addresses) {
+        return new RoundRobinSocketProviderImpl(addresses);
     }
 
     private Runnable createDiscoveryTask(TarantoolClusterDiscoverer serviceDiscoverer) {

--- a/src/test/java/org/tarantool/RoundRobinSocketProviderImplTest.java
+++ b/src/test/java/org/tarantool/RoundRobinSocketProviderImplTest.java
@@ -68,7 +68,7 @@ public class RoundRobinSocketProviderImplTest extends AbstractSocketProviderTest
     public void testDefaultTimeout() {
         RoundRobinSocketProviderImpl socketProvider
                 = new RoundRobinSocketProviderImpl("localhost");
-        assertEquals(RoundRobinSocketProviderImpl.NO_TIMEOUT, socketProvider.getTimeout());
+        assertEquals(RoundRobinSocketProviderImpl.NO_TIMEOUT, socketProvider.getConnectionTimeout());
     }
 
     @Test
@@ -77,8 +77,8 @@ public class RoundRobinSocketProviderImplTest extends AbstractSocketProviderTest
         RoundRobinSocketProviderImpl socketProvider
                 = new RoundRobinSocketProviderImpl("localhost");
         int expectedTimeout = 10_000;
-        socketProvider.setTimeout(expectedTimeout);
-        assertEquals(expectedTimeout, socketProvider.getTimeout());
+        socketProvider.setConnectionTimeout(expectedTimeout);
+        assertEquals(expectedTimeout, socketProvider.getConnectionTimeout());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class RoundRobinSocketProviderImplTest extends AbstractSocketProviderTest
         RoundRobinSocketProviderImpl socketProvider
                 = new RoundRobinSocketProviderImpl("localhost");
         int negativeValue = -200;
-        assertThrows(IllegalArgumentException.class, () -> socketProvider.setTimeout(negativeValue));
+        assertThrows(IllegalArgumentException.class, () -> socketProvider.setConnectionTimeout(negativeValue));
     }
 
     @Test
@@ -125,11 +125,11 @@ public class RoundRobinSocketProviderImplTest extends AbstractSocketProviderTest
         RoundRobinSocketProviderImpl socketProvider
                 = wrapWithMockChannelProvider(new RoundRobinSocketProviderImpl(addresses));
 
-        int retriesLimit = 5;
+        int retriesLimit = addresses.length + 1;
         socketProvider.setRetriesLimit(retriesLimit);
 
         for (int i = 0; i < retriesLimit; i++) {
-            socketProvider.get(0, null);
+            socketProvider.get(i, null);
             assertEquals(expectedAddress, extractRawHostAndPortString(socketProvider.getLastObtainedAddress()));
         }
 
@@ -141,7 +141,7 @@ public class RoundRobinSocketProviderImplTest extends AbstractSocketProviderTest
     public void testWrongAddress() throws IOException {
         RoundRobinSocketProviderImpl socketProvider
                 = wrapWithMockErroredChannelProvider(new RoundRobinSocketProviderImpl("unreachable-host:3301"));
-        assertThrows(CommunicationException.class, () -> socketProvider.get(0, null));
+        assertThrows(SocketProviderTransientException.class, () -> socketProvider.get(0, null));
     }
 
     @Test
@@ -149,7 +149,7 @@ public class RoundRobinSocketProviderImplTest extends AbstractSocketProviderTest
     public void testWrongRefreshAddress() throws IOException {
         RoundRobinSocketProviderImpl socketProvider
                 = wrapWithMockErroredChannelProvider(new RoundRobinSocketProviderImpl("unreachable-host:3301"));
-        assertThrows(CommunicationException.class, () -> socketProvider.get(0, null));
+        assertThrows(SocketProviderTransientException.class, () -> socketProvider.get(0, null));
     }
 
 }

--- a/src/test/java/org/tarantool/SingleSocketChannelProviderImplTest.java
+++ b/src/test/java/org/tarantool/SingleSocketChannelProviderImplTest.java
@@ -31,7 +31,7 @@ class SingleSocketChannelProviderImplTest extends AbstractSocketProviderTest {
     public void testDefaultTimeout() {
         RoundRobinSocketProviderImpl socketProvider
                 = new RoundRobinSocketProviderImpl("localhost");
-        assertEquals(RoundRobinSocketProviderImpl.NO_TIMEOUT, socketProvider.getTimeout());
+        assertEquals(RoundRobinSocketProviderImpl.NO_TIMEOUT, socketProvider.getConnectionTimeout());
     }
 
     @Test
@@ -40,8 +40,8 @@ class SingleSocketChannelProviderImplTest extends AbstractSocketProviderTest {
         RoundRobinSocketProviderImpl socketProvider
                 = new RoundRobinSocketProviderImpl("localhost");
         int expectedTimeout = 10_000;
-        socketProvider.setTimeout(expectedTimeout);
-        assertEquals(expectedTimeout, socketProvider.getTimeout());
+        socketProvider.setConnectionTimeout(expectedTimeout);
+        assertEquals(expectedTimeout, socketProvider.getConnectionTimeout());
     }
 
     @Test
@@ -50,7 +50,7 @@ class SingleSocketChannelProviderImplTest extends AbstractSocketProviderTest {
         RoundRobinSocketProviderImpl socketProvider
                 = new RoundRobinSocketProviderImpl("localhost");
         int negativeValue = -100;
-        assertThrows(IllegalArgumentException.class, () -> socketProvider.setTimeout(negativeValue));
+        assertThrows(IllegalArgumentException.class, () -> socketProvider.setConnectionTimeout(negativeValue));
     }
 
     @Test


### PR DESCRIPTION
Relax a socket provider contract. Now socket provider can throw a
transient error and the client will try to obtain a socket again instead
of being closed.

Make built-in socket providers configurable. Now the client can set
retries count and connection timeout for providers.

Update README doc im scope of new socket provider contract.

Closes: #167
Follows on: #144