### PR TITLE
Support Statement.closeOnCompletion.

### DIFF
--- a/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
+++ b/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
@@ -1126,8 +1126,8 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
         return new SQLNullResultSet(SQLResultHolder.ofQuery(meta, rows), createMetadataStatement());
     }
 
-    private SQLStatement createMetadataStatement() throws SQLException {
-        return connection.createStatement().unwrap(SQLStatement.class);
+    private TarantoolStatement createMetadataStatement() throws SQLException {
+        return connection.createStatement().unwrap(TarantoolStatement.class);
     }
 
     private static <T> T ensureType(Class<T> cls, Object v) throws Exception {
@@ -1152,7 +1152,7 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
 
     protected class SQLNullResultSet extends SQLResultSet {
 
-        public SQLNullResultSet(SQLResultHolder holder, SQLStatement ownerStatement) throws SQLException {
+        public SQLNullResultSet(SQLResultHolder holder, TarantoolStatement ownerStatement) throws SQLException {
             super(holder, ownerStatement);
         }
 

--- a/src/main/java/org/tarantool/jdbc/TarantoolStatement.java
+++ b/src/main/java/org/tarantool/jdbc/TarantoolStatement.java
@@ -1,0 +1,30 @@
+package org.tarantool.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Tarantool specific statement extensions.
+ */
+public interface TarantoolStatement extends Statement {
+
+    /**
+     * Checks for statement completion and closes itself,
+     * according to {@link Statement#closeOnCompletion()}.
+     */
+    void checkCompletion() throws SQLException;
+
+    /**
+     * Returns {@link ResultSet} which will be initialized by <code>data</code>.
+     *
+     * @param data predefined result to be wrapped by {@link ResultSet}
+     *
+     * @return wrapped result
+     *
+     * @throws SQLException if a database access error occurs or
+     *                      this method is called on a closed <code>Statement</code>
+     */
+    ResultSet executeMetadata(SQLResultHolder data) throws SQLException;
+
+}

--- a/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
@@ -167,8 +167,12 @@ public class JdbcResultSetIT extends JdbcTypesIT {
         assertNotNull(resultSet);
         ResultSetMetaData metaData = resultSet.getMetaData();
         assertNotNull(metaData);
+
+        int expectedColumnSize = 2;
+        assertEquals(expectedColumnSize, metaData.getColumnCount());
+
         resultSet.close();
-        assertEquals(metaData, resultSet.getMetaData());
+        assertEquals(expectedColumnSize, metaData.getColumnCount());
     }
 
     @Test


### PR DESCRIPTION
Check a statement after a dependent result set is closed.

Extract TarantoolStatement as tarantool specific extension interface to
be used for internal purposes as well as JDBC incompatible vendor API.

Closes: #180