### PR TITLE
Setup CI targets for tarantool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ language: java
 sudo: required
 dist: trusty
 
+jdk:
+  - openjdk8
+  - openjdk11
+  - openjdk12
+
+env:
+  - TNT_VERSION=1.9
+  - TNT_VERSION=1.10
+  - TNT_VERSION=2x
+  - TNT_VERSION=2.2
+
 stages:
   - checkstyle
   - test
@@ -10,16 +21,11 @@ stages:
 jobs:
   include:
     - stage: checkstyle
+      env: []
       jdk: openjdk11
       before_script: skip
       script: mvn checkstyle:check
       after_success: skip
-    - stage: test
-      jdk: openjdk8
-    - stage: test
-      jdk: openjdk11
-    - stage: test
-      jdk: openjdk12
 
 before_script:
   - .travis/travis.pre.sh

--- a/.travis/travis.build.sh
+++ b/.travis/travis.build.sh
@@ -2,7 +2,7 @@
 
 set -exu # Strict shell (w/o -o pipefail)
 
-if [ "${TRAVIS_JDK_VERSION}" = openjdk11 ]; then
+if [ "${TRAVIS_JDK_VERSION}" = "openjdk11" ] && [ "${TNT_VERSION}" = "2.2" ]; then
     mvn verify jacoco:report
 else
     mvn verify

--- a/.travis/travis.post.sh
+++ b/.travis/travis.post.sh
@@ -2,6 +2,6 @@
 
 set -exu # Strict shell (w/o -o pipefail)
 
-if [ "${TRAVIS_JDK_VERSION}" = openjdk11 ]; then
+if [ "${TRAVIS_JDK_VERSION}" = "openjdk11" ] && [ "${TNT_VERSION}" = "2.2" ]; then
     mvn coveralls:report -DrepoToken=${COVERALLS_TOKEN}
 fi

--- a/.travis/travis.pre.sh
+++ b/.travis/travis.pre.sh
@@ -2,14 +2,13 @@
 
 set -exuo pipefail # Strict shell
 
-# We need tarantool 2.* for jdbc/sql.
-curl http://download.tarantool.org/tarantool/2x/gpgkey | sudo apt-key add -
-release=`lsb_release -c -s`
+curl http://download.tarantool.org/tarantool/${TNT_VERSION}/gpgkey | sudo apt-key add -
+RELEASE=`lsb_release -c -s`
 
 sudo rm -f /etc/apt/sources.list.d/*tarantool*.list
-sudo tee /etc/apt/sources.list.d/tarantool_2x.list <<- EOF
-deb http://download.tarantool.org/tarantool/2x/ubuntu/ $release main
-deb-src http://download.tarantool.org/tarantool/2x/ubuntu/ $release main
+sudo tee /etc/apt/sources.list.d/tarantool_${TNT_VERSION/./_}.list <<- EOF
+deb http://download.tarantool.org/tarantool/${TNT_VERSION}/ubuntu/ ${RELEASE} main
+deb-src http://download.tarantool.org/tarantool/${TNT_VERSION}/ubuntu/ ${RELEASE} main
 EOF
 
 sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -281,7 +281,14 @@ base for possible answers and solutions.
 
 ## Building
 
-To run tests
-```
+To run unit tests use:
+ 
+```bash
 ./mvnw clean test
+``` 
+
+To run integration tests use:
+
+```bash
+./mvnw clean verify
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,9 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.jupiter.version>5.3.1</junit.jupiter.version>
+        <junit.jupiter.version>5.4.2</junit.jupiter.version>
+        <snakeyml.version>1.23</snakeyml.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
     <name>Tarantool Connector for Java</name>
     <url>https://github.com/tarantool/tarantool-java</url>
@@ -79,12 +81,12 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <goals>
@@ -172,13 +174,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.23</version>
+            <version>${snakeyml.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/tarantool/AbstractTarantoolSQLConnectorIT.java
+++ b/src/test/java/org/tarantool/AbstractTarantoolSQLConnectorIT.java
@@ -26,7 +26,6 @@ public abstract class AbstractTarantoolSQLConnectorIT {
     protected static final String LUA_FILE = "jdk-testing.lua";
     protected static final int LISTEN = 3301;
     protected static final int ADMIN = 3313;
-    protected static final int TIMEOUT = 500;
     protected static final int RESTART_TIMEOUT = 2000;
 
     protected static final SocketChannelProvider socketChannelProvider = new TestSocketChannelProvider(
@@ -36,46 +35,24 @@ public abstract class AbstractTarantoolSQLConnectorIT {
     protected static TarantoolControl control;
     protected static TarantoolConsole console;
 
-    protected static final String TABLE_NAME = "sql_test";
-
-    private static final String[] setupScript = new String[] {
-        "\\set language sql",
-        "\\set delimiter ;",
-
-        "CREATE TABLE sql_test (id INTEGER PRIMARY KEY, val VARCHAR(100));",
-        "CREATE UNIQUE INDEX sql_test_val_index_unique ON sql_test (val);",
-
-        "INSERT INTO sql_test VALUES (1, 'A');",
-        "INSERT INTO sql_test VALUES (2, 'B');",
-        "INSERT INTO sql_test VALUES (3, 'C');",
-    };
-
-    private static final String[] cleanScript = new String[] {
-        "DROP TABLE sql_test;"
-    };
-
     @BeforeAll
     public static void setupEnv() {
         control = new TarantoolControl();
         control.createInstance("jdk-testing", LUA_FILE, makeInstanceEnv(LISTEN, ADMIN));
         startTarantool("jdk-testing");
-
         console = openConsole();
-
-        executeLua(setupScript);
     }
 
     @AfterAll
     public static void cleanupEnv() {
         try {
-            executeLua(cleanScript);
             console.close();
         } finally {
             stopTarantool("jdk-testing");
         }
     }
 
-    private static void executeLua(String[] exprs) {
+    protected static void executeLua(String[] exprs) {
         for (String expr : exprs) {
             console.exec(expr);
         }

--- a/src/test/java/org/tarantool/AbstractTarantoolSQLOpsIT.java
+++ b/src/test/java/org/tarantool/AbstractTarantoolSQLOpsIT.java
@@ -2,7 +2,10 @@ package org.tarantool;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.tarantool.TestAssumptions.assumeMinimalServerVersion;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -13,7 +16,34 @@ import java.util.Map;
  */
 public abstract class AbstractTarantoolSQLOpsIT extends AbstractTarantoolSQLConnectorIT {
 
+    private static final String[] SETUP_SCRIPT = new String[] {
+        "\\set language sql",
+
+        "CREATE TABLE sql_test (id INTEGER PRIMARY KEY, val VARCHAR(100));",
+        "CREATE UNIQUE INDEX sql_test_val_index_unique ON sql_test (val);",
+
+        "INSERT INTO sql_test VALUES (1, 'A');",
+        "INSERT INTO sql_test VALUES (2, 'B');",
+        "INSERT INTO sql_test VALUES (3, 'C');"
+    };
+
+    private static final String[] CLEAN_SCRIPT = new String[] {
+        "DROP TABLE sql_test;",
+        "\\set language lua"
+    };
+
     protected abstract TarantoolSQLOps<Object, Long, List<Map<String, Object>>> getSQLOps();
+
+    @BeforeEach
+    void setUpTest() {
+        assumeMinimalServerVersion(console, ServerVersion.V_2_1);
+        executeLua(SETUP_SCRIPT);
+    }
+
+    @AfterEach
+    void tearDownTest() {
+        executeLua(CLEAN_SCRIPT);
+    }
 
     @Test
     public void testSelectOne() {

--- a/src/test/java/org/tarantool/SQLOperationsIT.java
+++ b/src/test/java/org/tarantool/SQLOperationsIT.java
@@ -22,7 +22,9 @@ public class SQLOperationsIT extends AbstractTarantoolSQLOpsIT {
 
     @AfterEach
     public void tearDown() {
-        client.close();
+        if (client != null) {
+            client.close();
+        }
     }
 
     @Override

--- a/src/test/java/org/tarantool/ServerVersion.java
+++ b/src/test/java/org/tarantool/ServerVersion.java
@@ -1,0 +1,74 @@
+package org.tarantool;
+
+import java.util.function.BiFunction;
+
+public enum ServerVersion {
+
+    V_1_9("1", "9", "0"),
+    V_1_10("1", "10", "0"),
+    V_2_1("2", "1", "0"),
+    V_2_2("2", "2", "0");
+
+    private final String majorVersion;
+    private final String minorVersion;
+    private final String patchVersion;
+
+    ServerVersion(String majorVersion,
+                  String minorVersion, String patchVersion) {
+        this.majorVersion = majorVersion;
+        this.minorVersion = minorVersion;
+        this.patchVersion = patchVersion;
+    }
+
+    public String getMajorVersion() {
+        return majorVersion;
+    }
+
+    public String getMinorVersion() {
+        return minorVersion;
+    }
+
+    public String getPatchVersion() {
+        return patchVersion;
+    }
+
+    public boolean haveMinimalVersion(String versionString) {
+        return compareVersions(versionString, (server, minimal) -> server >= minimal);
+    }
+
+    public boolean haveMaximalVersion(String versionString) {
+        return compareVersions(versionString, (server, maximal) -> server <= maximal);
+    }
+
+    private boolean compareVersions(String versionString, BiFunction<Integer, Integer, Boolean> comparator) {
+        int parsedVersion = toNumber(splitVersionParts(versionString));
+        int thisVersion = toNumber(new String[] { majorVersion, minorVersion, patchVersion });
+        return comparator.apply(parsedVersion, thisVersion);
+    }
+
+    /**
+     * Translates version parts to format XXXYYYZZZ.
+     * For example, {@code 1.2.1} translates to number {@code 1002001}
+     *
+     * @param parts version parts
+     * @return version as number
+     */
+    private int toNumber(String[] parts) {
+        int version = 0;
+        for (int i = 0; i < 3; i++) {
+            version = (version + Integer.parseInt(parts[i])) * 1000;
+        }
+        return version / 1000;
+    }
+
+    /**
+     * Splits Tarantool version string into parts.
+     * For example, {@code 2.1.1-423-g4007436aa} => {@code [2, 1, 1, 423, g4007436aa]}.
+     *
+     * @param version Tarantool version string
+     * @return split parts
+     */
+    private String[] splitVersionParts(String version) {
+        return version.split("[.\\-]");
+    }
+}

--- a/src/test/java/org/tarantool/TestAssumptions.java
+++ b/src/test/java/org/tarantool/TestAssumptions.java
@@ -1,0 +1,15 @@
+package org.tarantool;
+
+import org.junit.jupiter.api.Assumptions;
+
+public class TestAssumptions {
+
+    public static void assumeMinimalServerVersion(TarantoolConsole console, ServerVersion version) {
+        Assumptions.assumeTrue(version.haveMinimalVersion(TestUtils.getTarantoolVersion(console)));
+    }
+
+    public static void assumeMaximalServerVersion(TarantoolConsole console, ServerVersion version) {
+        Assumptions.assumeTrue(version.haveMaximalVersion(TestUtils.getTarantoolVersion(console)));
+    }
+
+}

--- a/src/test/java/org/tarantool/TestUtils.java
+++ b/src/test/java/org/tarantool/TestUtils.java
@@ -75,6 +75,10 @@ public class TestUtils {
         return env;
     }
 
+    protected static String getTarantoolVersion(TarantoolConsole console) {
+        return console.eval("return box.info.version");
+    }
+
     /**
      * See waitReplication(TarantoolClientImpl client, int timeout).
      */

--- a/src/test/java/org/tarantool/jdbc/JdbcDriverTest.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcDriverTest.java
@@ -31,6 +31,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 public class JdbcDriverTest {
+
     @Test
     public void testParseQueryString() throws Exception {
         SQLDriver drv = new SQLDriver();

--- a/src/test/java/org/tarantool/jdbc/JdbcExceptionHandlingTest.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcExceptionHandlingTest.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.Properties;
 
 public class JdbcExceptionHandlingTest {
+
     /**
      * Simulates meta parsing error: missing "name" field in a space format for the primary key.
      *


### PR DESCRIPTION
- Add new CI targets for the following TNT versions: 1.9, 1.10, 2x,
  and 2.2 against JDKs versions 8, 11, and 12.
- Add assume-style checks to skip Tarantool version incompatible tests.
- Update testing tools versions in POM.
- Update 'Building' section of README file how to run test w\o SQL part.

Closes: #52, #143