### PR TITLE
Support a Statement.getMoreResults feature

### DIFF
--- a/src/main/java/org/tarantool/jdbc/SQLStatement.java
+++ b/src/main/java/org/tarantool/jdbc/SQLStatement.java
@@ -218,13 +218,21 @@ public class SQLStatement implements TarantoolStatement {
 
     @Override
     public boolean getMoreResults() throws SQLException {
-        checkNotClosed();
-        return false;
+        return getMoreResults(Statement.CLOSE_CURRENT_RESULT);
     }
 
     @Override
     public boolean getMoreResults(int current) throws SQLException {
         checkNotClosed();
+        JdbcConstants.checkCurrentResultConstant(current);
+        if (resultSet != null &&
+            (current == KEEP_CURRENT_RESULT || current == CLOSE_ALL_RESULTS)) {
+            throw new SQLFeatureNotSupportedException();
+        }
+
+        // the driver doesn't support multiple results
+        // close current result and return no-more-results flag
+        discardLastResults();
         return false;
     }
 

--- a/src/main/java/org/tarantool/util/JdbcConstants.java
+++ b/src/main/java/org/tarantool/util/JdbcConstants.java
@@ -27,6 +27,14 @@ public class JdbcConstants {
         }
     }
 
+    public static void checkCurrentResultConstant(int currentResult) throws SQLException {
+        if (currentResult != Statement.CLOSE_CURRENT_RESULT &&
+            currentResult != Statement.CLOSE_ALL_RESULTS &&
+            currentResult != Statement.KEEP_CURRENT_RESULT) {
+            throw new SQLNonTransientException("", SQLStates.INVALID_PARAMETER_VALUE.getSqlState());
+        }
+    }
+
     public static class DatabaseMetadataTable {
 
         private DatabaseMetadataTable() {


### PR DESCRIPTION
Add support for two methods getMoreResults and its synonym
getMoreResults(CLOSE_CURRENT_RESULT). Tarantool does not support
multiple results per one query. It leads both KEEP_CURRENT_RESULT and
CLOSE_ALL_RESULTS modes are not supported by the driver.

Closes: #182