### PR TITLE
Filter wrong formatted discovery addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,7 @@ tarantool> function get_cluster_nodes() return { 'host1:3301', 'host2:3302', 'ho
 
 You need to pay attention to a function contract we are currently supporting:
 * The client never passes any arguments to a discovery function.
-* A discovery function _should_ return a single result of strings (i.e. single 
-  string `return 'host:3301'` or array of strings `return {'host1:3301', 'host2:3301'}`).
+* A discovery function _must_ return an array of strings (i.e `return {'host1:3301', 'host2:3301'}`).
 * A discovery function _may_ return multi-results but the client takes
   into account only first of them (i.e. `return {'host:3301'}, discovery_delay`, where 
   the second result is unused). Even more, any extra results __are reserved__ by the client

--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ tarantool> function get_cluster_nodes() return { 'host1:3301', 'host2:3302', 'ho
 You need to pay attention to a function contract we are currently supporting:
 * The client never passes any arguments to a discovery function.
 * A discovery function _must_ return an array of strings (i.e `return {'host1:3301', 'host2:3301'}`).
+* Each string _should_ satisfy the following pattern `host[:port]`
+  (or more strictly `/^[^:]+(:\d+)?$/` - a mandatory host containing any string
+  and an optional colon followed by digits of the port). Also, the port must be
+  in a range between 1 and 65535 if one is presented.
 * A discovery function _may_ return multi-results but the client takes
   into account only first of them (i.e. `return {'host:3301'}, discovery_delay`, where 
   the second result is unused). Even more, any extra results __are reserved__ by the client
@@ -270,6 +274,8 @@ client.syncOps().insert(45, Arrays.asList(1, 1));
 * A discovery task always uses an active client connection to get the nodes list.
   It's in your responsibility to provide a function availability as well as a consistent
   nodes list on all instances you initially set or obtain from the task.
+* Every address which is unmatched with `host[:port]` pattern will be filtered out from
+  the target addresses list.
 * If some error occurs while a discovery task is running then this task
   will be aborted without any after-effects for next task executions. These cases, for instance, are 
   a wrong function result (see discovery function contract) or a broken connection. 

--- a/src/main/java/org/tarantool/AbstractTarantoolOps.java
+++ b/src/main/java/org/tarantool/AbstractTarantoolOps.java
@@ -4,7 +4,7 @@ package org.tarantool;
 public abstract class AbstractTarantoolOps<Space, Tuple, Operation, Result>
     implements TarantoolClientOps<Space, Tuple, Operation, Result> {
 
-    private Code callCode = Code.OLD_CALL;
+    private Code callCode = Code.CALL;
 
     protected abstract Result exec(Code code, Object... args);
 

--- a/src/main/java/org/tarantool/TarantoolClientConfig.java
+++ b/src/main/java/org/tarantool/TarantoolClientConfig.java
@@ -44,10 +44,12 @@ public class TarantoolClientConfig {
     public long writeTimeoutMillis = 60 * 1000L;
 
     /**
-     * Use old call command https://github.com/tarantool/doc/issues/54,
-     * please ensure that you server supports new call command.
+     * Use new call method instead of obsolete
+     * {@code call_16} which used to work in Tarantool v1.6.
+     *
+     * Since 1.9.3, this flag has become enabled by default
      */
-    public boolean useNewCall = false;
+    public boolean useNewCall = true;
 
     /**
      *  Max time to establish connection to the server

--- a/src/main/java/org/tarantool/TarantoolClientImpl.java
+++ b/src/main/java/org/tarantool/TarantoolClientImpl.java
@@ -115,11 +115,11 @@ public class TarantoolClientImpl extends TarantoolBase<Future<?>> implements Tar
         this.syncOps = new SyncOps();
         this.composableAsyncOps = new ComposableAsyncOps();
         this.fireAndForgetOps = new FireAndForgetOps();
-        if (config.useNewCall) {
-            setCallCode(Code.CALL);
-            this.syncOps.setCallCode(Code.CALL);
-            this.fireAndForgetOps.setCallCode(Code.CALL);
-            this.composableAsyncOps.setCallCode(Code.CALL);
+        if (!config.useNewCall) {
+            setCallCode(Code.OLD_CALL);
+            this.syncOps.setCallCode(Code.OLD_CALL);
+            this.fireAndForgetOps.setCallCode(Code.OLD_CALL);
+            this.composableAsyncOps.setCallCode(Code.OLD_CALL);
         }
     }
 

--- a/src/main/java/org/tarantool/cluster/TarantoolClusterStoredFunctionDiscoverer.java
+++ b/src/main/java/org/tarantool/cluster/TarantoolClusterStoredFunctionDiscoverer.java
@@ -55,7 +55,7 @@ public class TarantoolClusterStoredFunctionDiscoverer implements TarantoolCluste
         if (result == null || result.isEmpty()) {
             throw new IllegalDiscoveryFunctionResult("Discovery function returned no data");
         }
-        if (!((List<Object>)result.get(0)).stream().allMatch(item -> item instanceof String)) {
+        if (!(result.get(0) instanceof List)) {
             throw new IllegalDiscoveryFunctionResult("The first value must be an array of strings");
         }
     }

--- a/src/main/java/org/tarantool/cluster/TarantoolClusterStoredFunctionDiscoverer.java
+++ b/src/main/java/org/tarantool/cluster/TarantoolClusterStoredFunctionDiscoverer.java
@@ -3,6 +3,7 @@ package org.tarantool.cluster;
 import org.tarantool.TarantoolClient;
 import org.tarantool.TarantoolClientOps;
 import org.tarantool.TarantoolClusterClientConfig;
+import org.tarantool.util.StringUtils;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -36,28 +37,57 @@ public class TarantoolClusterStoredFunctionDiscoverer implements TarantoolCluste
         // validation against the data returned;
         // this strict-mode allows us to extend the contract in a non-breaking
         // way for old clients just reserve an extra return value in
-        // terms of LUA multi-result support.
-        checkResult(list);
-
-        List<Object> funcResult = (List<Object>) list.get(0);
-        return funcResult.stream()
-                .map(Object::toString)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        // terms of Lua multi-result support.;
+        return checkAndFilterAddresses(list);
     }
 
     /**
      * Check whether the result follows the contract or not.
-     * The contract is a mandatory <b>single array of strings</b>
+     * The contract is a mandatory <b>single array of strings</b>.
+     *
+     * The simplified format for each string is host[:port].
      *
      * @param result result to be validated
      */
-    private void checkResult(List<?> result) {
+    private Set<String> checkAndFilterAddresses(List<?> result) {
         if (result == null || result.isEmpty()) {
             throw new IllegalDiscoveryFunctionResult("Discovery function returned no data");
         }
         if (!(result.get(0) instanceof List)) {
             throw new IllegalDiscoveryFunctionResult("The first value must be an array of strings");
         }
+
+        return ((List<Object>) result.get(0)).stream()
+            .filter(item -> item instanceof String)
+            .map(Object::toString)
+            .filter(s -> !StringUtils.isBlank(s))
+            .filter(this::isAddress)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Checks that address matches host[:port] format.
+     *
+     * @param address to be checked
+     * @return true if address follows the format
+     */
+    private boolean isAddress(String address) {
+        if (address.endsWith(":")) {
+            return false;
+        }
+        String[] addressParts = address.split(":");
+        if (addressParts.length > 2) {
+            return false;
+        }
+        if (addressParts.length == 2) {
+            try {
+                int port = Integer.parseInt(addressParts[1]);
+                return (port > 0 && port < 65536);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/src/test/java/org/tarantool/ClientAsyncOperationsIT.java
+++ b/src/test/java/org/tarantool/ClientAsyncOperationsIT.java
@@ -180,8 +180,7 @@ class ClientAsyncOperationsIT {
         testHelper.executeLua("function echo(...) return ... end");
 
         Future<List<?>> fut = provider.getAsyncOps().call("echo", "hello");
-        assertEquals(Collections.singletonList(Collections.singletonList("hello")),
-            fut.get(TIMEOUT, TimeUnit.MILLISECONDS));
+        assertEquals(Collections.singletonList("hello"), fut.get(TIMEOUT, TimeUnit.MILLISECONDS));
 
         provider.close();
     }

--- a/src/test/java/org/tarantool/ClientReconnectClusterIT.java
+++ b/src/test/java/org/tarantool/ClientReconnectClusterIT.java
@@ -359,7 +359,7 @@ public class ClientReconnectClusterIT {
         instances.get(SRV1)
             .executeLua("co = coroutine.create(function() " + functionBody + " end)");
         instances.get(SRV1)
-            .executeLua("function getAddressesFunction() local c, r = coroutine.resume(co); return r end");
+            .executeLua("function getAddressesFunction() local c, r = coroutine.resume(co); return {r} end");
 
         String infoFunctionScript = makeDiscoveryFunction(infoFunctionName, Collections.singletonList(service3Address));
         instances.get(SRV2).executeLua(infoFunctionScript);

--- a/src/test/java/org/tarantool/TarantoolClientOpsIT.java
+++ b/src/test/java/org/tarantool/TarantoolClientOpsIT.java
@@ -489,7 +489,7 @@ public class TarantoolClientOpsIT {
     @MethodSource("getClientOps")
     public void testCall(SyncOpsProvider provider) {
         assertEquals(
-            Collections.singletonList(Collections.singletonList("true")),
+            Collections.singletonList("true"),
             provider.getClientOps().call("echo", "true")
         );
 

--- a/src/test/java/org/tarantool/cluster/ClusterServiceStoredFunctionDiscovererIT.java
+++ b/src/test/java/org/tarantool/cluster/ClusterServiceStoredFunctionDiscovererIT.java
@@ -154,6 +154,18 @@ public class ClusterServiceStoredFunctionDiscovererIT {
     }
 
     @Test
+    @DisplayName("fetched with an exception when a single string returned")
+    public void testSingleStringResultData() {
+        String functionCode = makeDiscoveryFunction(ENTRY_FUNCTION_NAME, "'host1:3301'");
+        control.openConsole(INSTANCE_NAME).exec(functionCode);
+
+        TarantoolClusterStoredFunctionDiscoverer discoverer =
+            new TarantoolClusterStoredFunctionDiscoverer(clusterConfig, client);
+
+        assertThrows(IllegalDiscoveryFunctionResult.class, discoverer::getInstances);
+    }
+
+    @Test
     @DisplayName("fetched with an exception using no return function")
     public void testFunctionWithNoReturn() {
         String functionCode = makeDiscoveryFunction(ENTRY_FUNCTION_NAME, "");


### PR DESCRIPTION
Instead of discarding the full list of addresses when at least one
address does not match the format like host[:port] a discoverer just
skips this broken address and carries on processing.

Change discovery function requirements description in part of single
value support. This is done to be consistent with other Tarantool
connectors.

Closes: #195, #196