### PR TITLE
JDBC batch updates

### DIFF
--- a/src/main/java/org/tarantool/jdbc/SQLBatchResultHolder.java
+++ b/src/main/java/org/tarantool/jdbc/SQLBatchResultHolder.java
@@ -1,0 +1,26 @@
+package org.tarantool.jdbc;
+
+import java.util.List;
+
+/**
+ * Wrapper for batch SQL query results.
+ */
+public class SQLBatchResultHolder {
+
+    private final List<SQLResultHolder> results;
+    private final Exception error;
+
+    public SQLBatchResultHolder(List<SQLResultHolder> results, Exception error) {
+        this.results = results;
+        this.error = error;
+    }
+
+    public List<SQLResultHolder> getResults() {
+        return results;
+    }
+
+    public Exception getError() {
+        return error;
+    }
+
+}

--- a/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
+++ b/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
@@ -948,7 +948,7 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public boolean supportsBatchUpdates() throws SQLException {
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/org/tarantool/jdbc/SQLQueryHolder.java
+++ b/src/main/java/org/tarantool/jdbc/SQLQueryHolder.java
@@ -1,0 +1,28 @@
+package org.tarantool.jdbc;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SQLQueryHolder {
+
+    private final String query;
+    private final List<Object> params;
+
+    public static SQLQueryHolder of(String query, Object... params) {
+        return new SQLQueryHolder(query, Arrays.asList(params));
+    }
+
+    private SQLQueryHolder(String query, List<Object> params) {
+        this.query = query;
+        this.params = params;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public List<Object> getParams() {
+        return params;
+    }
+
+}

--- a/src/main/java/org/tarantool/jdbc/SQLResultHolder.java
+++ b/src/main/java/org/tarantool/jdbc/SQLResultHolder.java
@@ -11,9 +11,11 @@ import java.util.List;
  */
 public class SQLResultHolder {
 
-    final List<SqlProtoUtils.SQLMetaData> sqlMetadata;
-    final List<List<Object>> rows;
-    final int updateCount;
+    public static final int NO_UPDATE_COUNT = -1;
+
+    private final List<SqlProtoUtils.SQLMetaData> sqlMetadata;
+    private final List<List<Object>> rows;
+    private final int updateCount;
 
     public SQLResultHolder(List<SqlProtoUtils.SQLMetaData> sqlMetadata, List<List<Object>> rows, int updateCount) {
         this.sqlMetadata = sqlMetadata;
@@ -23,7 +25,7 @@ public class SQLResultHolder {
 
     public static SQLResultHolder ofQuery(final List<SqlProtoUtils.SQLMetaData> sqlMetadata,
                                           final List<List<Object>> rows) {
-        return new SQLResultHolder(sqlMetadata, rows, -1);
+        return new SQLResultHolder(sqlMetadata, rows, NO_UPDATE_COUNT);
     }
 
     public static SQLResultHolder ofEmptyQuery() {

--- a/src/test/java/org/tarantool/jdbc/JdbcExceptionHandlingTest.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcExceptionHandlingTest.java
@@ -3,6 +3,7 @@ package org.tarantool.jdbc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -151,17 +152,12 @@ public class JdbcExceptionHandlingTest {
         throws SQLException {
         Exception ex = new CommunicationException("TEST");
         SQLTarantoolClientImpl.SQLRawOps sqlOps = mock(SQLTarantoolClientImpl.SQLRawOps.class);
-        doThrow(ex).when(sqlOps).execute("TEST");
+        doThrow(ex).when(sqlOps).execute(anyObject());
 
         SQLTarantoolClientImpl client = buildSQLClient(sqlOps, null);
         final Statement stmt = new SQLStatement(buildTestSQLConnection(client, "jdbc:tarantool://0:0"));
 
-        SQLException e = assertThrows(SQLException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                consumer.accept(stmt);
-            }
-        });
+        SQLException e = assertThrows(SQLException.class, () -> consumer.accept(stmt));
         assertTrue(e.getMessage().startsWith("Failed to execute"), e.getMessage());
 
         assertEquals(ex, e.getCause());
@@ -173,7 +169,7 @@ public class JdbcExceptionHandlingTest {
         throws SQLException {
         Exception ex = new CommunicationException("TEST");
         SQLTarantoolClientImpl.SQLRawOps sqlOps = mock(SQLTarantoolClientImpl.SQLRawOps.class);
-        doThrow(ex).when(sqlOps).execute("TEST");
+        doThrow(ex).when(sqlOps).execute(anyObject());
 
         SQLTarantoolClientImpl client = buildSQLClient(sqlOps, null);
         final PreparedStatement prep = new SQLPreparedStatement(


### PR DESCRIPTION
Add support for JDBC batch updates. It includes an implementation of
Statement.*Batch(...) as well as PreparedStatement.*Batch() methods.

Under the hood SQLConnection uses the pipelining sending requests one by
one asynchronously and awaiting all of them. There are some issues
regarding vinyl storage engine where execution order are not specified
and DDL statements which are not transactional.

Closes: #62