### PR TITLE
Poolable statement hint

### DIFF
--- a/src/main/java/org/tarantool/jdbc/SQLPreparedStatement.java
+++ b/src/main/java/org/tarantool/jdbc/SQLPreparedStatement.java
@@ -41,6 +41,7 @@ public class SQLPreparedStatement extends SQLStatement implements PreparedStatem
         super(connection);
         this.sql = sql;
         this.parameters = new HashMap<>();
+        setPoolable(true);
     }
 
     public SQLPreparedStatement(SQLConnection connection,
@@ -51,6 +52,7 @@ public class SQLPreparedStatement extends SQLStatement implements PreparedStatem
         super(connection, resultSetType, resultSetConcurrency, resultSetHoldability);
         this.sql = sql;
         this.parameters = new HashMap<>();
+        setPoolable(true);
     }
 
     @Override

--- a/src/main/java/org/tarantool/jdbc/SQLStatement.java
+++ b/src/main/java/org/tarantool/jdbc/SQLStatement.java
@@ -50,6 +50,14 @@ public class SQLStatement implements TarantoolStatement {
      */
     private long timeout;
 
+    /**
+     * Hint to the statement pool implementation indicating
+     * whether the application wants the statement to be pooled.
+     *
+     * Ignored.
+     */
+    private boolean poolable;
+
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
     protected SQLStatement(SQLConnection sqlConnection) throws SQLException {
@@ -329,12 +337,14 @@ public class SQLStatement implements TarantoolStatement {
 
     @Override
     public void setPoolable(boolean poolable) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        checkNotClosed();
+        this.poolable = poolable;
     }
 
     @Override
     public boolean isPoolable() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        checkNotClosed();
+        return poolable;
     }
 
     /**

--- a/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcPreparedStatementIT.java
@@ -477,6 +477,14 @@ public class JdbcPreparedStatementIT {
         assertThrows(SQLException.class, () -> prep.addBatch("INSERT INTO test(id, val) VALUES (1, 'one')"));
     }
 
+    @Test
+    void testPoolableStatus() throws SQLException {
+        prep = conn.prepareStatement("SELECT val FROM test WHERE id = ?");
+        assertTrue(prep.isPoolable());
+        prep.setPoolable(false);
+        assertFalse(prep.isPoolable());
+    }
+
     private List<?> consoleSelect(Object key) {
         List<?> list = testHelper.evaluate(TestUtils.toLuaSelect("TEST", key));
         return list == null ? Collections.emptyList() : (List<?>) list.get(0);

--- a/src/test/java/org/tarantool/jdbc/JdbcStatementIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcStatementIT.java
@@ -527,6 +527,13 @@ public class JdbcStatementIT {
         assertEquals("six", consoleSelect(6).get(1));
     }
 
+    @Test
+    void testPoolableStatus() throws SQLException {
+        assertFalse(stmt.isPoolable());
+        stmt.setPoolable(true);
+        assertTrue(stmt.isPoolable());
+    }
+
     private List<?> consoleSelect(Object key) {
         List<?> list = testHelper.evaluate(TestUtils.toLuaSelect("TEST", key));
         return list == null ? Collections.emptyList() : (List<?>) list.get(0);


### PR DESCRIPTION
Implement corresponding API related to poolable statements. This hint
is ignored and used to be compatible with the API.

Closes: #181