### PR TITLE
Fix NoSuchMethodError when Buffer.clear() is called

### DIFF
--- a/src/main/java/org/tarantool/protocol/ProtoUtils.java
+++ b/src/main/java/org/tarantool/protocol/ProtoUtils.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.NonReadableChannelException;
 import java.nio.channels.ReadableByteChannel;
@@ -180,7 +181,7 @@ public abstract class ProtoUtils {
         assertCorrectWelcome(firstLine, channel.getRemoteAddress());
         final String serverVersion = firstLine.substring(WELCOME.length());
 
-        welcomeBytes.clear();
+        ((Buffer)welcomeBytes).clear();
         channel.read(welcomeBytes);
         String salt = new String(welcomeBytes.array());
 


### PR DESCRIPTION
Tarantool client uses java.nio.ByteBuffer to represent a payload to be
sent through the network. JDK 9 introduces a number of new methods that
override java.nio.Buffer methods in order to return ByteBuffer instead
of Buffer. Because of overriding, those methods are available in JRE 8
or below but cannot be invoked if the connector is built using JDK 9 or
above using new signatures for methods overridden. To be compatible
with JREs before 9, it possible to cast ByteBuffer to Buffer class
explicitly. As a result, a method will be called which is available in
older versions but it breaks conciseness of the code.

Closes: #215