### PR TITLE
Support new types introduced in Tarantool 2.2

### DIFF
--- a/src/main/java/org/tarantool/jdbc/type/TarantoolSqlType.java
+++ b/src/main/java/org/tarantool/jdbc/type/TarantoolSqlType.java
@@ -10,23 +10,33 @@ public enum TarantoolSqlType {
 
     UNKNOWN(TarantoolType.UNKNOWN, JdbcType.UNKNOWN, "unknown"),
 
+    // float, double, real used to be number aliases before 2.2
     FLOAT(TarantoolType.NUMBER, JdbcType.FLOAT, "float"),
     DOUBLE(TarantoolType.NUMBER, JdbcType.DOUBLE, "double"),
     REAL(TarantoolType.NUMBER, JdbcType.REAL, "real"),
+    // was introduced in Tarantool 2.2.1
+    NUMBER(TarantoolType.NUMBER, JdbcType.DOUBLE, "number"),
 
-    INT(TarantoolType.INTEGER, JdbcType.INTEGER, "int"),
-    INTEGER(TarantoolType.INTEGER, JdbcType.INTEGER, "integer"),
+    INT(TarantoolType.INTEGER, JdbcType.BIGINT, "int"),
+    INTEGER(TarantoolType.INTEGER, JdbcType.BIGINT, "integer"),
+    // was introduced in 2.2
+    UNSIGNED(TarantoolType.UNSIGNED, JdbcType.BIGINT, "integer"),
 
+    // were introduced in 2.2
     BOOL(TarantoolType.BOOLEAN, JdbcType.BOOLEAN, "bool"),
     BOOLEAN(TarantoolType.BOOLEAN, JdbcType.BOOLEAN, "boolean"),
 
+    STRING(TarantoolType.STRING, JdbcType.VARCHAR, "string"),
+    TEXT(TarantoolType.STRING, JdbcType.VARCHAR, "text"),
     VARCHAR(TarantoolType.STRING, JdbcType.VARCHAR, "varchar") {
         @Override
         public String getDisplayType() {
             return getTypeName() + "(128)";
         }
     },
-    TEXT(TarantoolType.STRING, JdbcType.VARCHAR, "text"),
+
+    // was introduced in 2.2
+    VARBINARY(TarantoolType.VARBINARY, JdbcType.VARBINARY, "varbinary"),
 
     SCALAR(TarantoolType.SCALAR, JdbcType.BINARY, "scalar");
 
@@ -34,9 +44,11 @@ public enum TarantoolSqlType {
     static {
         defaultSqlTypeMapping = new HashMap<>();
         defaultSqlTypeMapping.put(TarantoolType.BOOLEAN, TarantoolSqlType.BOOLEAN);
-        defaultSqlTypeMapping.put(TarantoolType.STRING, TarantoolSqlType.VARCHAR);
+        defaultSqlTypeMapping.put(TarantoolType.STRING, TarantoolSqlType.STRING);
         defaultSqlTypeMapping.put(TarantoolType.INTEGER, TarantoolSqlType.INTEGER);
-        defaultSqlTypeMapping.put(TarantoolType.NUMBER, TarantoolSqlType.DOUBLE);
+        defaultSqlTypeMapping.put(TarantoolType.UNSIGNED, TarantoolSqlType.UNSIGNED);
+        defaultSqlTypeMapping.put(TarantoolType.NUMBER, TarantoolSqlType.NUMBER);
+        defaultSqlTypeMapping.put(TarantoolType.VARBINARY, TarantoolSqlType.VARBINARY);
         defaultSqlTypeMapping.put(TarantoolType.SCALAR, TarantoolSqlType.SCALAR);
     }
 

--- a/src/main/java/org/tarantool/jdbc/type/TarantoolType.java
+++ b/src/main/java/org/tarantool/jdbc/type/TarantoolType.java
@@ -10,9 +10,12 @@ public enum TarantoolType {
     STRING("string", false, true, Integer.MAX_VALUE, 0, Integer.MAX_VALUE),
     // precision is 20 due to Tarantool integer type has range [-2^63-1..2^64-1]
     INTEGER("integer", true, false, 20, 0, 20),
+    // precision is 20 due to Tarantool unsigned integer type has range [0..2^64-1]
+    UNSIGNED("unsigned", false, false, 20, 0, 20),
     // precision is 20 due to Tarantool allows both integer and floating-point values under number type
     NUMBER("number", true, false, 20, 16, 24),
-    SCALAR("scalar", false, true, Integer.MAX_VALUE, 0, Integer.MAX_VALUE);
+    SCALAR("scalar", false, true, Integer.MAX_VALUE, 0, Integer.MAX_VALUE),
+    VARBINARY("varbinary", false, true, Integer.MAX_VALUE, 0, Integer.MAX_VALUE);
 
     private final String typeName;
     private final boolean signed;

--- a/src/test/java/org/tarantool/ServerVersion.java
+++ b/src/test/java/org/tarantool/ServerVersion.java
@@ -7,7 +7,8 @@ public enum ServerVersion {
     V_1_9("1", "9", "0"),
     V_1_10("1", "10", "0"),
     V_2_1("2", "1", "0"),
-    V_2_2("2", "2", "0");
+    V_2_2("2", "2", "0"),
+    V_2_2_1("2", "2", "1");
 
     private final String majorVersion;
     private final String minorVersion;
@@ -32,12 +33,16 @@ public enum ServerVersion {
         return patchVersion;
     }
 
-    public boolean haveMinimalVersion(String versionString) {
+    public boolean isLessOrEqualThan(String versionString) {
         return compareVersions(versionString, (server, minimal) -> server >= minimal);
     }
 
-    public boolean haveMaximalVersion(String versionString) {
+    public boolean isGreaterOrEqualThan(String versionString) {
         return compareVersions(versionString, (server, maximal) -> server <= maximal);
+    }
+
+    public boolean isGreaterThan(String versionString) {
+        return compareVersions(versionString, (server, maximal) -> server < maximal);
     }
 
     private boolean compareVersions(String versionString, BiFunction<Integer, Integer, Boolean> comparator) {

--- a/src/test/java/org/tarantool/TestAssumptions.java
+++ b/src/test/java/org/tarantool/TestAssumptions.java
@@ -5,11 +5,21 @@ import org.junit.jupiter.api.Assumptions;
 public class TestAssumptions {
 
     public static void assumeMinimalServerVersion(String rawVersion, ServerVersion version) {
-        Assumptions.assumeTrue(version.haveMinimalVersion(rawVersion));
+        Assumptions.assumeTrue(version.isLessOrEqualThan(rawVersion));
     }
 
     public static void assumeMaximalServerVersion(String rawVersion, ServerVersion version) {
-        Assumptions.assumeTrue(version.haveMaximalVersion(rawVersion));
+        Assumptions.assumeTrue(version.isGreaterOrEqualThan(rawVersion));
+    }
+
+    public static void assumeServerVersionLessThan(String rawVersion, ServerVersion version) {
+        Assumptions.assumeTrue(version.isGreaterThan(rawVersion));
+    }
+
+    public static void assumeServerVersionOutOfRange(String rawVersion,
+                                                     ServerVersion left,
+                                                     ServerVersion right) {
+        Assumptions.assumeFalse(left.isLessOrEqualThan(rawVersion) && right.isGreaterThan(rawVersion));
     }
 
 }


### PR DESCRIPTION
There are a few new types such as BOOLEAN(BOOL), UNSIGNED in Tarantool
v2.2. Moreover, Number aliases REAL, FLOAT, DOUBLE were replaced by one
NUMBER type since v2.2.1.

Support tests for old number types on version before 2.2.