### PR TITLE
Check support for named fields in update/upsert

### DIFF
--- a/src/test/java/org/tarantool/ClientOperationsIT.java
+++ b/src/test/java/org/tarantool/ClientOperationsIT.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.tarantool.TestAssertions.checkRawTupleResult;
+import static org.tarantool.TestAssumptions.assumeMinimalServerVersion;
 
 import org.tarantool.schema.TarantoolIndexNotFoundException;
 import org.tarantool.schema.TarantoolSpaceNotFoundException;
@@ -78,8 +79,8 @@ public class ClientOperationsIT {
         client.syncOps().insert("basic_test", Arrays.asList(1, "one"));
         client.syncOps().insert("basic_test", Arrays.asList(10, "ten"));
 
-        checkRawTupleResult(consoleSelect(1), Arrays.asList(1, "one"));
-        checkRawTupleResult(consoleSelect(10), Arrays.asList(10, "ten"));
+        checkRawTupleResult(consoleSelect("basic_test", 1), Arrays.asList(1, "one"));
+        checkRawTupleResult(consoleSelect("basic_test", 10), Arrays.asList(10, "ten"));
     }
 
     @Test
@@ -90,8 +91,8 @@ public class ClientOperationsIT {
         client.syncOps().replace("basic_test", Arrays.asList(1, "one"));
         client.syncOps().replace("basic_test", Arrays.asList(10, "ten"));
 
-        checkRawTupleResult(consoleSelect(1), Arrays.asList(1, "one"));
-        checkRawTupleResult(consoleSelect(10), Arrays.asList(10, "ten"));
+        checkRawTupleResult(consoleSelect("basic_test", 1), Arrays.asList(1, "one"));
+        checkRawTupleResult(consoleSelect("basic_test", 10), Arrays.asList(10, "ten"));
     }
 
     @Test
@@ -103,9 +104,9 @@ public class ClientOperationsIT {
         client.syncOps().delete("basic_test", Collections.singletonList(1));
         client.syncOps().delete("basic_test", Collections.singletonList(20));
 
-        assertEquals(Collections.emptyList(), consoleSelect(1));
-        checkRawTupleResult(consoleSelect(10), Arrays.asList(10, "10"));
-        assertEquals(Collections.emptyList(), consoleSelect(20));
+        assertEquals(Collections.emptyList(), consoleSelect("basic_test", 1));
+        checkRawTupleResult(consoleSelect("basic_test", 10), Arrays.asList(10, "10"));
+        assertEquals(Collections.emptyList(), consoleSelect("basic_test", 20));
     }
 
     @Test
@@ -118,9 +119,9 @@ public class ClientOperationsIT {
         clientOps.update("basic_test", Collections.singletonList(2), Arrays.asList("=", 1, "two"));
         clientOps.update("basic_test", Collections.singletonList(10), Arrays.asList("=", 1, "ten"));
 
-        checkRawTupleResult(consoleSelect(1), Arrays.asList(1, "one"));
-        assertEquals(Collections.emptyList(), consoleSelect(2));
-        checkRawTupleResult(consoleSelect(10), Arrays.asList(10, "ten"));
+        checkRawTupleResult(consoleSelect("basic_test", 1), Arrays.asList(1, "one"));
+        assertEquals(Collections.emptyList(), consoleSelect("basic_test", 2));
+        checkRawTupleResult(consoleSelect("basic_test", 10), Arrays.asList(10, "ten"));
     }
 
     @Test
@@ -142,9 +143,9 @@ public class ClientOperationsIT {
             Arrays.asList(10, "010"), Arrays.asList("=", 1, "ten")
         );
 
-        checkRawTupleResult(consoleSelect(1), Arrays.asList(1, "one"));
-        checkRawTupleResult(consoleSelect(2), Arrays.asList(2, "002"));
-        checkRawTupleResult(consoleSelect(10), Arrays.asList(10, "ten"));
+        checkRawTupleResult(consoleSelect("basic_test", 1), Arrays.asList(1, "one"));
+        checkRawTupleResult(consoleSelect("basic_test", 2), Arrays.asList(2, "002"));
+        checkRawTupleResult(consoleSelect("basic_test", 10), Arrays.asList(10, "ten"));
     }
 
     @Test
@@ -229,8 +230,114 @@ public class ClientOperationsIT {
         testHelper.executeLua("box.space.base_test_unknown:drop()");
     }
 
-    private List<?> consoleSelect(Object key) {
-        return testHelper.evaluate(TestUtils.toLuaSelect("basic_test", key));
+    @Test
+    void testNamedFieldUpdate() {
+        assumeMinimalServerVersion(testHelper.getInstanceVersion(), ServerVersion.V_2_3);
+        testHelper.executeLua("box.space.basic_test:insert{1, '1'}");
+        testHelper.executeLua("box.space.basic_test:insert{10, '10'}");
+
+        TarantoolClientOps<Integer, List<?>, Object, List<?>> clientOps = client.syncOps();
+        clientOps.update("basic_test", Collections.singletonList(1), Arrays.asList("=", "val", "un"));
+        clientOps.update("basic_test", Collections.singletonList(2), Arrays.asList("=", "val", "deux"));
+        clientOps.update("basic_test", Collections.singletonList(10), Arrays.asList("=", "val", "dix"));
+
+        checkRawTupleResult(consoleSelect("basic_test", 1), Arrays.asList(1, "un"));
+        assertEquals(Collections.emptyList(), consoleSelect("basic_test", 2));
+        checkRawTupleResult(consoleSelect("basic_test", 10), Arrays.asList(10, "dix"));
+    }
+
+    @Test
+    void testWrongNamedFieldUpdate() {
+        assumeMinimalServerVersion(testHelper.getInstanceVersion(), ServerVersion.V_2_3);
+        testHelper.executeLua("box.space.basic_test:insert{1, '1'}");
+
+        TarantoolClientOps<Integer, List<?>, Object, List<?>> clientOps = client.syncOps();
+        TarantoolException exception = assertThrows(
+            TarantoolException.class,
+            () -> clientOps.update("basic_test", Collections.singletonList(1), Arrays.asList("=", "wrong", "un"))
+        );
+        assertEquals(exception.getMessage(), "Field 'wrong' was not found in the tuple");
+    }
+
+    @Test
+    void testNamedFieldUpsert() {
+        assumeMinimalServerVersion(testHelper.getInstanceVersion(), ServerVersion.V_2_3);
+        testHelper.executeLua("box.space.basic_test:insert{1, '1'}");
+        testHelper.executeLua("box.space.basic_test:insert{10, '10'}");
+
+        TarantoolClientOps<Integer, List<?>, Object, List<?>> ops = client.syncOps();
+        ops.upsert(
+            "basic_test", Collections.singletonList(1),
+            Arrays.asList(1, "un"), Arrays.asList("=", "val", "one")
+        );
+        ops.upsert(
+            "basic_test", Collections.singletonList(2),
+            Arrays.asList(2, "deux"), Arrays.asList("=", "val", "two")
+        );
+        ops.upsert(
+            "basic_test", Collections.singletonList(10),
+            Arrays.asList(10, "dix"), Arrays.asList("=", "val", "ten")
+        );
+
+        checkRawTupleResult(consoleSelect("basic_test", 1), Arrays.asList(1, "one"));
+        checkRawTupleResult(consoleSelect("basic_test", 2), Arrays.asList(2, "deux"));
+        checkRawTupleResult(consoleSelect("basic_test", 10), Arrays.asList(10, "ten"));
+    }
+
+    @Test
+    void testWrongNamedFieldUpsert() {
+        assumeMinimalServerVersion(testHelper.getInstanceVersion(), ServerVersion.V_2_3);
+        testHelper.executeLua("box.space.basic_test:insert{1, '1'}");
+
+        TarantoolClientOps<Integer, List<?>, Object, List<?>> ops = client.syncOps();
+        TarantoolException exception = assertThrows(
+            TarantoolException.class,
+            () -> {
+                ops.upsert(
+                    "basic_test", Collections.singletonList(1),
+                    Arrays.asList(1, "un"), Arrays.asList("=", "bad_field", "one")
+                );
+            }
+        );
+        assertEquals(exception.getMessage(), "Field 'bad_field' was not found in the tuple");
+    }
+
+    @Test
+    void testUpdateNamedFieldsOperations() {
+        assumeMinimalServerVersion(testHelper.getInstanceVersion(), ServerVersion.V_2_3);
+        testHelper.executeLua(
+            "box.schema.space.create('animals', { format = " +
+                "{ {name = 'id', type = 'integer'}," +
+                "  {name = 'name', type = 'string'}," +
+                "  {name = 'mph', type = 'integer'}," +
+                "  {name = 'habitat', type = 'string', is_nullable = true} } })",
+            "box.space.animals:create_index('pk', { type = 'TREE', parts = {'id'} } )",
+
+            "box.space.animals:insert{1, 'Golden eagle', 200}",
+            "box.space.animals:insert{2, 'Cheetah', 75}",
+            "box.space.animals:insert{3, 'lion', 30, 'Africa'}"
+        );
+
+        TarantoolClientOps<Integer, List<?>, Object, List<?>> ops = client.syncOps();
+        ops.update("animals", Collections.singletonList(1), Arrays.asList("!", "habitat", "North America"));
+        ops.update("animals", Collections.singletonList(3), Arrays.asList("=", "name", "Lion"));
+        ops.update("animals", Collections.singletonList(3), Arrays.asList("+", "mph", 20));
+        ops.update("animals", Collections.singletonList(3), Arrays.asList("#", "habitat", 1));
+        ops.upsert(
+            "animals", Collections.singletonList(4),
+            Arrays.asList(4, "Swordfish", 60), Arrays.asList("=", "mph", 60)
+        );
+
+        checkRawTupleResult(consoleSelect("animals", 1), Arrays.asList(1, "Golden eagle", 200, "North America"));
+        checkRawTupleResult(consoleSelect("animals", 2), Arrays.asList(2, "Cheetah", 75));
+        checkRawTupleResult(consoleSelect("animals", 3), Arrays.asList(3, "Lion", 50));
+        checkRawTupleResult(consoleSelect("animals", 4), Arrays.asList(4, "Swordfish", 60));
+
+        testHelper.executeLua("box.space.animals:drop()");
+    }
+
+    private List<?> consoleSelect(String spaceName, Object key) {
+        return testHelper.evaluate(TestUtils.toLuaSelect(spaceName, key));
     }
 
 }

--- a/src/test/java/org/tarantool/ServerVersion.java
+++ b/src/test/java/org/tarantool/ServerVersion.java
@@ -8,7 +8,8 @@ public enum ServerVersion {
     V_1_10("1", "10", "0"),
     V_2_1("2", "1", "0"),
     V_2_2("2", "2", "0"),
-    V_2_2_1("2", "2", "1");
+    V_2_2_1("2", "2", "1"),
+    V_2_3("2", "3", "0");
 
     private final String majorVersion;
     private final String minorVersion;


### PR DESCRIPTION
Add required tests that show support for named fields introduced in
Tarantool 2.3. This feature affects update and upsert operation
triplets allowing to use field names specified as a space format.

Extend operation DSL part to use named field in addition to numeric
ones.

Closes: #220