### PR TITLE
Use cluster Tarantool client instead of simple one

### DIFF
--- a/src/main/java/org/tarantool/RoundRobinSocketProviderImpl.java
+++ b/src/main/java/org/tarantool/RoundRobinSocketProviderImpl.java
@@ -61,7 +61,18 @@ public class RoundRobinSocketProviderImpl extends BaseSocketChannelProvider impl
      * @throws IllegalArgumentException if addresses aren't provided
      */
     public RoundRobinSocketProviderImpl(String... addresses) {
-        updateAddressList(Arrays.asList(addresses));
+        this(Arrays.asList(addresses));
+    }
+
+    /**
+     * Constructs an instance.
+     *
+     * @param addresses optional list of addresses in a form of host[:port]
+     *
+     * @throws IllegalArgumentException if addresses aren't provided
+     */
+    public RoundRobinSocketProviderImpl(List<String> addresses) {
+        updateAddressList(addresses);
         setRetriesLimit(DEFAULT_RETRIES_PER_CONNECTION);
     }
 

--- a/src/main/java/org/tarantool/TarantoolClusterClient.java
+++ b/src/main/java/org/tarantool/TarantoolClusterClient.java
@@ -10,7 +10,9 @@ import org.tarantool.util.StringUtils;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,6 +57,16 @@ public class TarantoolClusterClient extends TarantoolClientImpl {
      * @param addresses Array of addresses in the form of host[:port].
      */
     public TarantoolClusterClient(TarantoolClusterClientConfig config, String... addresses) {
+        this(config, makeClusterSocketProvider(Arrays.asList(addresses)));
+    }
+
+    /**
+     * Constructs a new cluster client.
+     *
+     * @param config    Configuration.
+     * @param addresses List of addresses in the form of host[:port].
+     */
+    public TarantoolClusterClient(TarantoolClusterClientConfig config, List<String> addresses) {
         this(config, makeClusterSocketProvider(addresses));
     }
 
@@ -270,7 +282,7 @@ public class TarantoolClusterClient extends TarantoolClientImpl {
         }
     }
 
-    private static RoundRobinSocketProviderImpl makeClusterSocketProvider(String[] addresses) {
+    private static RoundRobinSocketProviderImpl makeClusterSocketProvider(List<String> addresses) {
         return new RoundRobinSocketProviderImpl(addresses);
     }
 

--- a/src/main/java/org/tarantool/jdbc/SQLDriver.java
+++ b/src/main/java/org/tarantool/jdbc/SQLDriver.java
@@ -1,21 +1,27 @@
 package org.tarantool.jdbc;
 
 import org.tarantool.SocketChannelProvider;
-import org.tarantool.TarantoolClientConfig;
+import org.tarantool.TarantoolClusterClientConfig;
+import org.tarantool.util.NodeSpec;
 import org.tarantool.util.SQLStates;
 
-import java.net.URI;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public class SQLDriver implements Driver {
+
+    private static final String TARANTOOL_JDBC_SCHEME = "jdbc:tarantool:";
 
     static {
         try {
@@ -29,84 +35,160 @@ public class SQLDriver implements Driver {
 
     @Override
     public Connection connect(String url, Properties info) throws SQLException {
-        if (url == null) {
-            throw new SQLException("Url must not be null");
-        }
         if (!acceptsURL(url)) {
             return null;
         }
 
-        final URI uri = URI.create(url);
-        final Properties urlProperties = parseQueryString(uri, info);
-        String providerClassName = SQLProperty.SOCKET_CHANNEL_PROVIDER.getString(urlProperties);
+        final Properties urlProperties = parseConnectionString(url, info);
 
-        if (providerClassName == null) {
-            return new SQLConnection(url, urlProperties);
+        String[] hosts = SQLProperty.HOST.getString(urlProperties).split(",");
+        String[] ports = SQLProperty.PORT.getString(urlProperties).split(",");
+        List<NodeSpec> nodes = new ArrayList<>(hosts.length);
+        for (int i = 0; i < hosts.length; i++) {
+            nodes.add(new NodeSpec(hosts[i], Integer.valueOf(ports[i])));
         }
 
+        String providerClassName = SQLProperty.SOCKET_CHANNEL_PROVIDER.getString(urlProperties);
+        if (providerClassName == null) {
+            return new SQLConnection(url, nodes, urlProperties);
+        }
         final SocketChannelProvider provider = getSocketProviderInstance(providerClassName);
-
-        return new SQLConnection(url, urlProperties) {
+        return new SQLConnection(url, nodes, urlProperties) {
             @Override
-            protected SQLTarantoolClientImpl makeSqlClient(String address, TarantoolClientConfig config) {
+            protected SQLTarantoolClientImpl makeSqlClient(List<String> addresses,
+                                                           TarantoolClusterClientConfig config) {
                 return new SQLTarantoolClientImpl(provider, config);
             }
         };
     }
 
-    protected Properties parseQueryString(URI uri, Properties info) throws SQLException {
+    /**
+     * Parses an URL and to parameters and merges
+     * they with the parameters provided. If same
+     * parameter specified in both URL and properties
+     * the
+     *
+     * <p>
+     * jdbc:tarantool://[user-info@][nodes][?parameters]
+     * user-info ::= user[:password]
+     * nodes ::= host1[:port1][,host2[:port2] ... ]
+     * parameters ::= param1=value1[&param2=value2 ... ]
+     *
+     * @param url  target URL string
+     * @param info extra properties to be merged
+     *
+     * @return merged properties
+     *
+     * @throws SQLException if any invalid parameters are passed
+     */
+    protected Properties parseConnectionString(String url, Properties info) throws SQLException {
         Properties urlProperties = new Properties();
 
-        // get scheme specific part (after the scheme part "jdbc:")
-        // to correct parse remaining URL
-        uri = URI.create(uri.getSchemeSpecificPart());
-        String userInfo = uri.getUserInfo();
-        if (userInfo != null) {
-            // Get user and password from the corresponding part of the URI, i.e. before @ sign.
-            int i = userInfo.indexOf(':');
-            if (i < 0) {
-                SQLProperty.USER.setString(urlProperties, userInfo);
-            } else {
-                SQLProperty.USER.setString(urlProperties, userInfo.substring(0, i));
-                SQLProperty.PASSWORD.setString(urlProperties, userInfo.substring(i + 1));
-            }
+        String schemeSpecificPart = url.substring(TARANTOOL_JDBC_SCHEME.length());
+        if (!schemeSpecificPart.startsWith("//")) {
+            throw new SQLException("Invalid URL: '//' is not presented.");
         }
-        if (uri.getQuery() != null) {
-            String[] parts = uri.getQuery().split("&");
-            for (String part : parts) {
-                int i = part.indexOf("=");
-                if (i > -1) {
-                    urlProperties.put(part.substring(0, i), part.substring(i + 1));
-                } else {
-                    urlProperties.put(part, "");
-                }
-            }
+        int userInfoEndPosition = schemeSpecificPart.indexOf('@');
+        int queryStartPosition = schemeSpecificPart.indexOf('?');
+
+        if (userInfoEndPosition != -1) {
+            parseUserInfo(schemeSpecificPart.substring(2, userInfoEndPosition), urlProperties);
         }
-        if (uri.getHost() != null) {
-            // Default values are pre-put above.
-            urlProperties.setProperty(SQLProperty.HOST.getName(), uri.getHost());
+        if (queryStartPosition != -1) {
+            parseQueryParameters(schemeSpecificPart.substring(queryStartPosition + 1), urlProperties);
         }
-        if (uri.getPort() >= 0) {
-            // We need to convert port to string otherwise getProperty() will not see it.
-            urlProperties.setProperty(SQLProperty.PORT.getName(), String.valueOf(uri.getPort()));
-        }
+        String nodesPart = schemeSpecificPart.substring(
+            userInfoEndPosition == -1 ? 2 : userInfoEndPosition + 1,
+            queryStartPosition == -1 ? schemeSpecificPart.length() : queryStartPosition
+        );
+        parseNodes(nodesPart, urlProperties);
+
         if (info != null) {
             urlProperties.putAll(info);
         }
 
-        // Validate properties.
-        int port = SQLProperty.PORT.getInt(urlProperties);
-        if (port <= 0 || port > 65535) {
-            throw new SQLException("Port is out of range: " + port, SQLStates.INVALID_PARAMETER_VALUE.getSqlState());
-        }
-
-        checkTimeout(SQLProperty.LOGIN_TIMEOUT, urlProperties);
-        checkTimeout(SQLProperty.QUERY_TIMEOUT, urlProperties);
+        requirePortNumber(SQLProperty.PORT, urlProperties);
+        requireNonNegativeInteger(SQLProperty.LOGIN_TIMEOUT, urlProperties);
+        requireNonNegativeInteger(SQLProperty.QUERY_TIMEOUT, urlProperties);
+        requireNonNegativeInteger(SQLProperty.CLUSTER_DISCOVERY_DELAY_MILLIS, urlProperties);
 
         return urlProperties;
     }
 
-    private void checkTimeout(SQLProperty sqlProperty, Properties properties) throws SQLException {
+    private void parseUserInfo(String userInfo, Properties properties) {
+        int i = userInfo.indexOf(':');
+        if (i < 0) {
+            SQLProperty.USER.setString(properties, userInfo);
+        } else {
+            SQLProperty.USER.setString(properties, userInfo.substring(0, i));
+            SQLProperty.PASSWORD.setString(properties, userInfo.substring(i + 1));
+        }
+    }
+
+    private void parseNodes(String nodesPart, Properties properties) throws SQLException {
+        String[] nodes = nodesPart.split(",");
+        StringBuilder hosts = new StringBuilder();
+        StringBuilder ports = new StringBuilder();
+        for (String node : nodes) {
+            int portIndex = node.lastIndexOf(':');
+            if (portIndex != -1 && node.lastIndexOf(']') < portIndex) {
+                String portString = node.substring(portIndex + 1);
+                hosts.append(node, 0, portIndex);
+                ports.append(portString);
+            } else {
+                hosts.append(node);
+                ports.append(SQLProperty.PORT.getDefaultValue());
+            }
+            hosts.append(',');
+            ports.append(',');
+        }
+
+        hosts.setLength(hosts.length() - 1);
+        ports.setLength(ports.length() - 1);
+        SQLProperty.HOST.setString(properties, hosts.toString());
+        SQLProperty.PORT.setString(properties, ports.toString());
+    }
+
+    private void parseQueryParameters(String queryParams, Properties properties) throws SQLException {
+        String[] parts = queryParams.split("&");
+        for (String part : parts) {
+            int i = part.indexOf("=");
+            if (i > -1) {
+                String name = part.substring(0, i);
+                String value = null;
+                try {
+                    value = URLDecoder.decode(part.substring(i + 1), "UTF-8");
+                } catch (UnsupportedEncodingException cause) {
+                    throw new SQLException(cause.getMessage(), SQLStates.INVALID_PARAMETER_VALUE.getSqlState(), cause);
+                }
+                properties.put(name, value);
+            } else {
+                properties.put(part, "");
+            }
+        }
+    }
+
+    private void requirePortNumber(SQLProperty sqlProperty, Properties properties) throws SQLException {
+        String[] portList = sqlProperty.getString(properties).split(",");
+        for (String portString : portList) {
+            try {
+                int port = Integer.parseInt(portString);
+                if (port < 1 || port > 65535) {
+                    throw new SQLException(
+                        "Port is out of range: " + port, SQLStates.INVALID_PARAMETER_VALUE.getSqlState()
+                    );
+                }
+            } catch (NumberFormatException cause) {
+                throw new SQLException(
+                    "Property " + sqlProperty.getName() + " must be a valid number.",
+                    SQLStates.INVALID_PARAMETER_VALUE.getSqlState(),
+                    cause
+                );
+            }
+        }
+    }
+
+    private void requireNonNegativeInteger(SQLProperty sqlProperty, Properties properties) throws SQLException {
         int timeout = sqlProperty.getInt(properties);
         if (timeout < 0) {
             throw new SQLException(
@@ -143,30 +225,27 @@ public class SQLDriver implements Driver {
 
     @Override
     public boolean acceptsURL(String url) throws SQLException {
-        return url.toLowerCase().startsWith("jdbc:tarantool:");
+        if (url == null) {
+            throw new SQLException("Url must not be null");
+        }
+        return url.startsWith(TARANTOOL_JDBC_SCHEME);
     }
 
     @Override
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
-        try {
-            URI uri = new URI(url);
-            Properties properties = parseQueryString(uri, info);
-
-            SQLProperty[] sqlProperties = SQLProperty.values();
-            DriverPropertyInfo[] propertyInfoList = new DriverPropertyInfo[sqlProperties.length];
-            for (int i = 0; i < sqlProperties.length; i++) {
-                SQLProperty sqlProperty = sqlProperties[i];
-                String value = sqlProperty.getString(properties);
-                DriverPropertyInfo propertyInfo = new DriverPropertyInfo(sqlProperty.getName(), value);
-                propertyInfo.required = sqlProperty.isRequired();
-                propertyInfo.description = sqlProperty.getDescription();
-                propertyInfo.choices = sqlProperty.getChoices();
-                propertyInfoList[i] = propertyInfo;
-            }
-            return propertyInfoList;
-        } catch (Exception e) {
-            throw new SQLException(e);
+        Properties properties = parseConnectionString(url, info);
+        SQLProperty[] sqlProperties = SQLProperty.values();
+        DriverPropertyInfo[] propertyInfoList = new DriverPropertyInfo[sqlProperties.length];
+        for (int i = 0; i < sqlProperties.length; i++) {
+            SQLProperty sqlProperty = sqlProperties[i];
+            String value = sqlProperty.getString(properties);
+            DriverPropertyInfo propertyInfo = new DriverPropertyInfo(sqlProperty.getName(), value);
+            propertyInfo.required = sqlProperty.isRequired();
+            propertyInfo.description = sqlProperty.getDescription();
+            propertyInfo.choices = sqlProperty.getChoices();
+            propertyInfoList[i] = propertyInfo;
         }
+        return propertyInfoList;
     }
 
     @Override

--- a/src/main/java/org/tarantool/jdbc/SQLProperty.java
+++ b/src/main/java/org/tarantool/jdbc/SQLProperty.java
@@ -8,21 +8,21 @@ import java.util.Properties;
 public enum SQLProperty {
     HOST(
         "host",
-        "Tarantool server host",
+        "Tarantool server host (may be specified in the URL directly)",
         "localhost",
         null,
         true
     ),
     PORT(
         "port",
-        "Tarantool server port",
+        "Tarantool server port (may be specified in the URL directly)",
         "3301",
         null,
         true
     ),
     SOCKET_CHANNEL_PROVIDER(
         "socketChannelProvider",
-        "SocketProvider class implements org.tarantool.SocketChannelProvider",
+        "SocketProvider class that implements org.tarantool.SocketChannelProvider",
         null,
         null,
         false
@@ -54,6 +54,22 @@ public enum SQLProperty {
         "The number of milliseconds to wait before a timeout is occurred for the query. " +
             "The default value is 0 (infinite) timeout.",
         "0",
+        null,
+        false
+    ),
+    CLUSTER_DISCOVERY_ENTRY_FUNCTION(
+        "clusterDiscoveryEntryFunction",
+        "The name of the stored function to be used to fetch list of Tarantool instances." +
+            "It's unspecified by default.",
+        null,
+        null,
+        false
+    ),
+    CLUSTER_DISCOVERY_DELAY_MILLIS(
+        "clusterDiscoveryDelayMillis",
+        "A java.util.concurrent.Executor implementation that will be used to retry sending queries " +
+            "during a reconnaction. Default value is not specified.",
+        "60000",
         null,
         false
     );

--- a/src/main/java/org/tarantool/jdbc/ds/SQLDataSource.java
+++ b/src/main/java/org/tarantool/jdbc/ds/SQLDataSource.java
@@ -3,12 +3,15 @@ package org.tarantool.jdbc.ds;
 import org.tarantool.jdbc.SQLConnection;
 import org.tarantool.jdbc.SQLConstant;
 import org.tarantool.jdbc.SQLProperty;
+import org.tarantool.util.NodeSpec;
 
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -26,7 +29,7 @@ public class SQLDataSource implements TarantoolDataSource, DataSource {
 
     @Override
     public Connection getConnection() throws SQLException {
-        return new SQLConnection(makeUrl(), new Properties(properties));
+        return new SQLConnection(makeUrl(), makeNodeSpecs(), new Properties(properties));
     }
 
     @Override
@@ -34,7 +37,7 @@ public class SQLDataSource implements TarantoolDataSource, DataSource {
         Properties copyProperties = new Properties(properties);
         SQLProperty.USER.setString(copyProperties, username);
         SQLProperty.PASSWORD.setString(copyProperties, password);
-        return new SQLConnection(makeUrl(), copyProperties);
+        return new SQLConnection(makeUrl(), makeNodeSpecs(), copyProperties);
     }
 
     @Override
@@ -156,4 +159,10 @@ public class SQLDataSource implements TarantoolDataSource, DataSource {
             SQLProperty.HOST.getString(properties) + ":" + SQLProperty.PORT.getString(properties);
     }
 
+    private List<NodeSpec> makeNodeSpecs() throws SQLException {
+        return Collections.singletonList(new NodeSpec(
+            SQLProperty.HOST.getString(properties),
+            SQLProperty.PORT.getInt(properties)
+        ));
+    }
 }

--- a/src/main/java/org/tarantool/util/NodeSpec.java
+++ b/src/main/java/org/tarantool/util/NodeSpec.java
@@ -1,0 +1,27 @@
+package org.tarantool.util;
+
+/**
+ * Tarantool instance container.
+ */
+public class NodeSpec {
+    private final String host;
+    private final Integer port;
+
+    public NodeSpec(String host, Integer port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public String toString() {
+        return host + (port != null ? ":" + port : "");
+    }
+}

--- a/src/test/java/org/tarantool/jdbc/JdbcConnectionTimeoutIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcConnectionTimeoutIT.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.tarantool.TestAssumptions.assumeMinimalServerVersion;
 
 import org.tarantool.ServerVersion;
-import org.tarantool.TarantoolClientConfig;
+import org.tarantool.TarantoolClusterClientConfig;
 import org.tarantool.TarantoolTestHelper;
 import org.tarantool.protocol.TarantoolPacket;
 
@@ -21,6 +21,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
 import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 public class JdbcConnectionTimeoutIT {
@@ -46,10 +48,11 @@ public class JdbcConnectionTimeoutIT {
     @BeforeEach
     void setUp() throws SQLException {
         assumeMinimalServerVersion(testHelper.getInstanceVersion(), ServerVersion.V_2_1);
-        connection = new SQLConnection("", new Properties()) {
+        connection = new SQLConnection("", Collections.emptyList(), new Properties()) {
             @Override
-            protected SQLTarantoolClientImpl makeSqlClient(String address, TarantoolClientConfig config) {
-                return new SQLTarantoolClientImpl(address, config) {
+            protected SQLTarantoolClientImpl makeSqlClient(List<String> addresses,
+                                                           TarantoolClusterClientConfig config) {
+                return new SQLTarantoolClientImpl(addresses, config) {
                     @Override
                     protected void completeSql(TarantoolOp<?> operation, TarantoolPacket pack) {
                         try {

--- a/src/test/java/org/tarantool/jdbc/JdbcExceptionHandlingTest.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcExceptionHandlingTest.java
@@ -19,8 +19,8 @@ import static org.tarantool.jdbc.SQLDatabaseMetadata._VINDEX;
 import static org.tarantool.jdbc.SQLDatabaseMetadata._VSPACE;
 
 import org.tarantool.CommunicationException;
-import org.tarantool.TarantoolClientConfig;
 import org.tarantool.TarantoolClientOps;
+import org.tarantool.TarantoolClusterClientConfig;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -227,9 +227,10 @@ public class JdbcExceptionHandlingTest {
                                                  String url,
                                                  Properties properties)
         throws SQLException {
-        return new SQLConnection(url, properties) {
+        return new SQLConnection(url, Collections.emptyList(), properties) {
             @Override
-            protected SQLTarantoolClientImpl makeSqlClient(String address, TarantoolClientConfig config) {
+            protected SQLTarantoolClientImpl makeSqlClient(List<String> addresses,
+                                                           TarantoolClusterClientConfig config) {
                 return client;
             }
         };

--- a/src/test/java/org/tarantool/jdbc/JdbcFailOverConnectionIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcFailOverConnectionIT.java
@@ -1,0 +1,140 @@
+package org.tarantool.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.tarantool.TestAssumptions.assumeMinimalServerVersion;
+import static org.tarantool.TestUtils.makeDiscoveryFunction;
+import static org.tarantool.jdbc.SqlTestUtils.makeDefaulJdbcUrl;
+
+import org.tarantool.ServerVersion;
+import org.tarantool.TarantoolTestHelper;
+import org.tarantool.TestUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Extends the {@link org.tarantool.ClientReconnectClusterIT} test suite.
+ */
+@DisplayName("A JDBC clustered connection")
+public class JdbcFailOverConnectionIT {
+
+    private static String REPLICATION_CONFIG = TestUtils.makeReplicationString(
+        TarantoolTestHelper.USERNAME,
+        TarantoolTestHelper.PASSWORD,
+        "localhost:3401",
+        "localhost:3402"
+    );
+
+    private static final String[] BEFORE_SQL = {
+        "DROP TABLE IF EXISTS countries",
+        "CREATE TABLE countries(id INT PRIMARY KEY, name VARCHAR(100))",
+        "INSERT INTO countries VALUES (67, 'Greece')",
+        "INSERT INTO countries VALUES (77, 'Iceland')",
+    };
+
+    private static TarantoolTestHelper primaryNode;
+    private static TarantoolTestHelper secondaryNode;
+
+    private Connection connection;
+
+    @BeforeAll
+    public static void setupEnv() {
+        primaryNode = new TarantoolTestHelper("sql-replica1-it");
+        secondaryNode = new TarantoolTestHelper("sql-replica2-it");
+        primaryNode.createInstance(
+            TarantoolTestHelper.LUA_FILE,
+            3401,
+            3501,
+            REPLICATION_CONFIG,
+            0.1
+        );
+        secondaryNode.createInstance(
+            TarantoolTestHelper.LUA_FILE,
+            3402,
+            3502,
+            REPLICATION_CONFIG,
+            0.1
+        );
+    }
+
+    @BeforeEach
+    public void setUpTest() {
+        primaryNode.startInstanceAsync();
+        secondaryNode.startInstanceAsync();
+        primaryNode.awaitStart();
+        secondaryNode.awaitStart();
+
+        primaryNode.executeSql(BEFORE_SQL);
+    }
+
+    @AfterEach
+    public void tearDownTest() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+        primaryNode.stopInstance();
+        secondaryNode.stopInstance();
+    }
+
+    @Test
+    public void testQueryFailOver() throws SQLException {
+        assumeMinimalServerVersion(primaryNode.getInstanceVersion(), ServerVersion.V_2_1);
+        connection = DriverManager.getConnection(
+            makeDefaulJdbcUrl("localhost:3401,localhost:3402", Collections.emptyMap())
+        );
+        assertFalse(connection.isClosed());
+
+        checkSynchronized(connection);
+        primaryNode.stopInstance();
+        checkSynchronized(connection);
+        secondaryNode.stopInstance();
+        assertTrue(connection.isClosed());
+    }
+
+    @Test
+    public void testRefreshNodes() throws SQLException {
+        assumeMinimalServerVersion(primaryNode.getInstanceVersion(), ServerVersion.V_2_1);
+        primaryNode.executeLua(
+            makeDiscoveryFunction("fetchNodes", Arrays.asList("localhost:3401", "localhost:3402"))
+        );
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(SQLProperty.CLUSTER_DISCOVERY_ENTRY_FUNCTION.getName(), "fetchNodes");
+        connection = DriverManager.getConnection(makeDefaulJdbcUrl("localhost:3401", parameters));
+        assertFalse(connection.isClosed());
+
+        checkSynchronized(connection);
+        primaryNode.stopInstance();
+        checkSynchronized(connection);
+        secondaryNode.stopInstance();
+        assertTrue(connection.isClosed());
+    }
+
+    private void checkSynchronized(Connection connection) throws SQLException {
+        try (
+            Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery("SELECT * FROM countries");
+        ) {
+            resultSet.next();
+            assertEquals("Greece", resultSet.getString("name"));
+            resultSet.next();
+            assertEquals("Iceland", resultSet.getString("name"));
+        }
+    }
+}
+

--- a/src/test/java/org/tarantool/jdbc/SqlTestUtils.java
+++ b/src/test/java/org/tarantool/jdbc/SqlTestUtils.java
@@ -1,22 +1,43 @@
 package org.tarantool.jdbc;
 
+import org.tarantool.TarantoolTestHelper;
+
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SqlTestUtils {
 
     public static String makeDefaultJdbcUrl() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(SQLProperty.USER.getName(), TarantoolTestHelper.USERNAME);
+        parameters.put(SQLProperty.PASSWORD.getName(), TarantoolTestHelper.PASSWORD);
         return makeJdbcUrl(
-            System.getProperty("tntHost", "localhost"),
-            Integer.valueOf(System.getProperty("tntPort", "3301")),
-            System.getProperty("tntUser", "test_admin"),
-            System.getProperty("tntPass", "4pWBZmLEgkmKK5WP")
+            TarantoolTestHelper.HOST + ":" + TarantoolTestHelper.PORT,
+            parameters
         );
     }
 
-    public static String makeJdbcUrl(String host, int port, String user, String password) {
-        return String.format("jdbc:tarantool://%s:%d?user=%s&password=%s", host, port, user, password);
+    public static String makeDefaulJdbcUrl(String address, Map<String, String> parameters) {
+        Map<String, String> params = new HashMap<>(parameters);
+        params.put(SQLProperty.USER.getName(), TarantoolTestHelper.USERNAME);
+        params.put(SQLProperty.PASSWORD.getName(), TarantoolTestHelper.PASSWORD);
+        return makeJdbcUrl(address, params);
+    }
+
+    public static String makeJdbcUrl(String address, Map<String, String> parameters) {
+        StringBuilder url = new StringBuilder("jdbc:tarantool://");
+        url.append(address).append("?");
+        parameters.forEach((k, v) -> {
+            url.append(k)
+                .append("=")
+                .append(v)
+                .append("&");
+        });
+        url.setLength(url.length() - 1);
+        return url.toString();
     }
 
     public static List<List<Object>> makeSingletonListResult(Object... rows) {


### PR DESCRIPTION
To support fail-over capabilities and node discovery mechanism,
SQLConnection uses TarantoolClusterClient under the hood.

Closes: #199