### PR TITLE
jdbc: support for DatabaseMetaData.getSQLStateType

### DIFF
--- a/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
+++ b/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
@@ -1037,7 +1037,7 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
 
     @Override
     public int getSQLStateType() throws SQLException {
-        return 0;
+        return DatabaseMetaData.sqlStateSQL;
     }
 
     @Override

--- a/src/test/java/org/tarantool/jdbc/JdbcDatabaseMetaDataIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcDatabaseMetaDataIT.java
@@ -390,4 +390,9 @@ public class JdbcDatabaseMetaDataIT {
         }
     }
 
+    @Test
+    public void testSqlStateType() throws SQLException {
+        assertEquals(DatabaseMetaData.sqlStateSQL, meta.getSQLStateType());
+    }
+
 }


### PR DESCRIPTION
Now we use SQLSTATE codes in most of the exceptional cases. To be
consistent with it we need to return an appropriate value from the
database metadata.

This commit changes the constant that says the driver works with
SQLSTATE codes rather than XOpen ones.

Closes #119