### PR TITLE
readme: update connector version to 1.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To get the Java connector for Tarantool 1.6.9, visit
 <dependency>
   <groupId>org.tarantool</groupId>
   <artifactId>connector</artifactId>
-  <version>1.9.2</version>
+  <version>1.9.4</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Users often copy-paste this hunk for Maven and receive the old connector
version with known problems. It seems we should update README after each
release to cleanly state that we recommend the last version to use.

Follows up b1e4b592c155a1ab83da6d3bdb5f156239e65cd9 ('readme: add a link
to releases page').