### PR TITLE
travis-ci: add tarantool-2.4 and 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ jdk:
 env:
   - TNT_VERSION=1.9
   - TNT_VERSION=1.10
-  - TNT_VERSION=2x
+  - TNT_VERSION=2.1
   - TNT_VERSION=2.2
   - TNT_VERSION=2.3
+  - TNT_VERSION=2.4
+  - TNT_VERSION=2.5
 
 stages:
   - checkstyle


### PR DESCRIPTION
Also changed 2x repository name to 2.1, because now
download.tarantool.org properly redirects 2x to 2.1.