### PR TITLE
travis-ci: run javadoc linter with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
       env: []
       jdk: openjdk11
       before_script: skip
-      script: mvn checkstyle:check
+      script: mvn checkstyle:check javadoc:javadoc
       after_success: skip
 
 before_script:

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,15 @@
                         <consoleOutput>true</consoleOutput>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     </configuration>
+            </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <source>8</source>
+                        <failOnWarnings>true</failOnWarnings>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
It should help to fix javadoc issues much early then during mvn release:clean release:prepare.

Fixes #244