### PR TITLE
travis-ci: don't fail on 'example' instance stop

### DIFF
--- a/.travis/travis.pre.sh
+++ b/.travis/travis.pre.sh
@@ -14,4 +14,9 @@ EOF
 sudo apt-get update
 sudo apt-get -y install tarantool tarantool-common
 
-sudo tarantoolctl stop example
+# Stop 'example' instance if it exists.
+#
+# See https://github.com/tarantool/tarantool/issues/4507
+if [ -e /etc/tarantool/instances.enabled/example.lua ]; then
+    sudo tarantoolctl stop example
+fi


### PR DESCRIPTION
The 'example' instance in not installed by default in tarantool-2.4
since 2.4.1-66-g78a9f8698, in tarantool-2.5 since 2.5.0-133-g080beba06
and in all further tarantool versions; see [1] for more information.

[1]: https://github.com/tarantool/tarantool/issues/4507